### PR TITLE
chore: renaming to beet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# @metaplex-foundation/borsh
+# @metaplex-foundation/beet
 
-Borsh compatible De/Serializer
+Strict borsh compatible de/serializer.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@metaplex-foundation/borsh",
+  "name": "@metaplex-foundation/beet",
   "version": "0.0.0",
-  "description": "Borsh compatible De/Serializer",
-  "main": "dist/src/bors.js",
-  "types": "dist/src/borsh.d.ts",
+  "description": "Strict borsh compatible de/serializer",
+  "main": "dist/src/beet.js",
+  "types": "dist/src/beet.d.ts",
   "scripts": {
     "check:publish-ready": "yarn build && yarn test",
     "preversion": "yarn check:publish-ready",
@@ -18,7 +18,7 @@
     "lint:fix": "prettier --format ./src",
     "doc": "typedoc src/*.ts --readme README.md"
   },
-  "repository": "git@github.com:metaplex-foundation/borsh.git",
+  "repository": "git@github.com:metaplex-foundation/beet.git",
   "author": "Thorsten Lorenz <thlorenz@gmx.de>",
   "license": "MIT",
   "private": false,

--- a/src/collections.ts
+++ b/src/collections.ts
@@ -1,9 +1,9 @@
-import { Borsh } from './types'
+import { Beet } from './types'
 import { strict as assert } from 'assert'
 
-export const fixedSizeUtf8String: (
+export const fixedSizeUtf8String: (stringByteLength: number) => Beet<string> = (
   stringByteLength: number
-) => Borsh<string> = (stringByteLength: number) => {
+) => {
   return {
     write: function (buf: Buffer, offset: number, value: string) {
       const stringBuf = Buffer.from(value, 'utf8')

--- a/src/composites.ts
+++ b/src/composites.ts
@@ -1,12 +1,12 @@
 import { strict as assert } from 'assert'
-import { Borsh } from './types'
+import { Beet } from './types'
 
 export type COption<T> = T | null
 
 const SOME = Buffer.from(Uint8Array.from([1, 0, 0, 0])).slice(0, 4)
 const NONE = Buffer.from(Uint8Array.from([0, 0, 0, 0])).slice(0, 4)
 
-export function coption<T>(inner: Borsh<T>): Borsh<COption<T>> {
+export function coption<T>(inner: Beet<T>): Beet<COption<T>> {
   return {
     write: function (buf: Buffer, offset: number, value: COption<T>) {
       if (value == null) {

--- a/src/numbers.ts
+++ b/src/numbers.ts
@@ -1,10 +1,10 @@
 import BN from 'bn.js'
-import { bignum, Borsh } from './types'
+import { bignum, Beet } from './types'
 
 // -----------------
 // Unsigned
 // -----------------
-export const u8: Borsh<number> = {
+export const u8: Beet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeUInt8(value, offset)
   },
@@ -15,7 +15,7 @@ export const u8: Borsh<number> = {
   description: 'primitive: u8',
 }
 
-export const u16: Borsh<number> = {
+export const u16: Beet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeUInt16LE(value, offset)
   },
@@ -26,7 +26,7 @@ export const u16: Borsh<number> = {
   description: 'primitive: u16',
 }
 
-export const u32: Borsh<number> = {
+export const u32: Beet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeUInt32LE(value, offset)
   },
@@ -37,7 +37,7 @@ export const u32: Borsh<number> = {
   description: 'primitive: u32',
 }
 
-function unsignedLargeBorsh(byteSize: number, description: string) {
+function unsignedLargeBeet(byteSize: number, description: string) {
   return {
     write: function (buf: Buffer, offset: number, value: bignum) {
       const bn = BN.isBN(value) ? value : new BN(value)
@@ -54,15 +54,15 @@ function unsignedLargeBorsh(byteSize: number, description: string) {
   }
 }
 
-export const u64: Borsh<bignum> = unsignedLargeBorsh(8, 'primitive: u64')
-export const u128: Borsh<bignum> = unsignedLargeBorsh(16, 'primitive: u128')
-export const u256: Borsh<bignum> = unsignedLargeBorsh(32, 'primitive: u256')
-export const u512: Borsh<bignum> = unsignedLargeBorsh(64, 'primitive: u512')
+export const u64: Beet<bignum> = unsignedLargeBeet(8, 'primitive: u64')
+export const u128: Beet<bignum> = unsignedLargeBeet(16, 'primitive: u128')
+export const u256: Beet<bignum> = unsignedLargeBeet(32, 'primitive: u256')
+export const u512: Beet<bignum> = unsignedLargeBeet(64, 'primitive: u512')
 
 // -----------------
 // Signed
 // -----------------
-export const i8: Borsh<number> = {
+export const i8: Beet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeInt8(value, offset)
   },
@@ -73,7 +73,7 @@ export const i8: Borsh<number> = {
   description: 'primitive: i8',
 }
 
-export const i16: Borsh<number> = {
+export const i16: Beet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeInt16LE(value, offset)
   },
@@ -84,7 +84,7 @@ export const i16: Borsh<number> = {
   description: 'primitive: i16',
 }
 
-export const i32: Borsh<number> = {
+export const i32: Beet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeInt32LE(value, offset)
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,12 @@
 import BN from 'bn.js'
 
-export type Borsh<T> = {
+export type Beet<T> = {
   write(buf: Buffer, offset: number, value: T): void
   read(buf: Buffer, offset: number): T
   byteSize: number
   description: string
 }
 
-export type BorshField<T> = [keyof T, Borsh<T[keyof T]>]
+export type BeetField<T> = [keyof T, Beet<T[keyof T]>]
 
 export type bignum = number | BN

--- a/test/collections.ts
+++ b/test/collections.ts
@@ -1,26 +1,26 @@
-import { Borsh, fixedSizeUtf8String } from '../src/borsh'
+import { Beet, fixedSizeUtf8String } from '../src/beet'
 import test from 'tape'
 
 function checkCases(
   offsets: number[],
   cases: string[],
-  borsh: Borsh<string>,
+  beet: Beet<string>,
   t: test.Test
 ) {
   for (const offset of offsets) {
     for (const x of cases) {
       {
         // Larger buffer
-        const buf = Buffer.alloc(offset + borsh.byteSize + offset)
-        borsh.write(buf, offset, x)
-        const y = borsh.read(buf, offset)
+        const buf = Buffer.alloc(offset + beet.byteSize + offset)
+        beet.write(buf, offset, x)
+        const y = beet.read(buf, offset)
         t.equal(x, y, `round trip ${x}, offset ${offset} larger buffer`)
       }
       {
         // Exact buffer
-        const buf = Buffer.alloc(offset + borsh.byteSize)
-        borsh.write(buf, offset, x)
-        const y = borsh.read(buf, offset)
+        const buf = Buffer.alloc(offset + beet.byteSize)
+        beet.write(buf, offset, x)
+        const y = beet.read(buf, offset)
         t.equal(x, y, `round trip ${x}, offset ${offset} exact buffer`)
       }
     }
@@ -30,35 +30,35 @@ function checkCases(
 test('collections: fixed size utf8 strings size 1', (t) => {
   const cases = ['a', 'b', 'z']
   const offsets = [0, 4]
-  const borsh = fixedSizeUtf8String(1)
+  const beet = fixedSizeUtf8String(1)
 
-  checkCases(offsets, cases, borsh, t)
+  checkCases(offsets, cases, beet, t)
   t.end()
 })
 
 test('collections: fixed size utf8 strings size 3', (t) => {
   const cases = ['abc', 'xYz']
   const offsets = [0, 4]
-  const borsh = fixedSizeUtf8String(3)
+  const beet = fixedSizeUtf8String(3)
 
-  checkCases(offsets, cases, borsh, t)
+  checkCases(offsets, cases, beet, t)
   t.end()
 })
 
 test('collections: fixed size utf8 strings size 4', (t) => {
   const cases = ['abcd', '😁']
   const offsets = [0, 4]
-  const borsh = fixedSizeUtf8String(4)
+  const beet = fixedSizeUtf8String(4)
 
-  checkCases(offsets, cases, borsh, t)
+  checkCases(offsets, cases, beet, t)
   t.end()
 })
 
 test('collections: fixed size utf8 incorrect size', (t) => {
   const s = '😁'
-  const borsh = fixedSizeUtf8String(3)
+  const beet = fixedSizeUtf8String(3)
   const buf = Buffer.alloc(4)
-  t.throws(() => borsh.write(buf, 0, s), /invalid byte size/)
+  t.throws(() => beet.write(buf, 0, s), /invalid byte size/)
 
   t.end()
 })

--- a/test/composites.ts
+++ b/test/composites.ts
@@ -1,33 +1,33 @@
 import {
-  Borsh,
+  Beet,
   coption,
   COption,
   fixedSizeUtf8String,
   u32,
   u8,
-} from '../src/borsh'
+} from '../src/beet'
 import test from 'tape'
 
 function checkCases<T>(
   offsets: number[],
   cases: COption<T>[],
-  borsh: Borsh<COption<T>>,
+  beet: Beet<COption<T>>,
   t: test.Test
 ) {
   for (const offset of offsets) {
     for (const x of cases) {
       {
         // Larger buffer
-        const buf = Buffer.alloc(offset + borsh.byteSize + offset)
-        borsh.write(buf, 0, x)
-        const y = borsh.read(buf, 0)
+        const buf = Buffer.alloc(offset + beet.byteSize + offset)
+        beet.write(buf, 0, x)
+        const y = beet.read(buf, 0)
         t.equal(x, y, `round trip ${x}, offset ${offset} larger buffer`)
       }
       {
         // Exact buffer
-        const buf = Buffer.alloc(offset + borsh.byteSize)
-        borsh.write(buf, offset, x)
-        const y = borsh.read(buf, offset)
+        const buf = Buffer.alloc(offset + beet.byteSize)
+        beet.write(buf, offset, x)
+        const y = beet.read(buf, offset)
         t.equal(x, y, `round trip ${x}, offset ${offset} exact buffer`)
       }
     }
@@ -37,26 +37,26 @@ function checkCases<T>(
 test('composites: COption<u8>', (t) => {
   const cases = [1, 2, null, 0xff]
   const offsets = [0, 4]
-  const borsh: Borsh<COption<number>> = coption(u8)
+  const beet: Beet<COption<number>> = coption(u8)
 
-  checkCases(offsets, cases, borsh, t)
+  checkCases(offsets, cases, beet, t)
   t.end()
 })
 
 test('composites: COption<u32>', (t) => {
   const cases = [1, null, 0xff, 0xffff, 0xffffffff]
   const offsets = [0, 4]
-  const borsh: Borsh<COption<number>> = coption(u32)
+  const beet: Beet<COption<number>> = coption(u32)
 
-  checkCases(offsets, cases, borsh, t)
+  checkCases(offsets, cases, beet, t)
   t.end()
 })
 
 test('composites: COption<string>', (t) => {
   const cases = ['abc', 'xyz', null]
   const offsets = [0, 2]
-  const borsh: Borsh<COption<string>> = coption(fixedSizeUtf8String(3))
+  const beet: Beet<COption<string>> = coption(fixedSizeUtf8String(3))
 
-  checkCases(offsets, cases, borsh, t)
+  checkCases(offsets, cases, beet, t)
   t.end()
 })

--- a/test/numbers.ts
+++ b/test/numbers.ts
@@ -2,7 +2,7 @@ import BN from 'bn.js'
 import test from 'tape'
 import {
   bignum,
-  Borsh,
+  Beet,
   i16,
   i32,
   i8,
@@ -13,7 +13,7 @@ import {
   u512,
   u64,
   u8,
-} from '../src/borsh'
+} from '../src/beet'
 
 function oneType(
   x: bignum,
@@ -30,16 +30,16 @@ function oneType(
 function checkCases(
   offsets: number[],
   cases: bignum[],
-  borsh: Borsh<bignum>,
+  beet: Beet<bignum>,
   t: test.Test
 ) {
   for (const offset of offsets) {
     for (const x of cases) {
       {
         // Larger buffer
-        const buf = Buffer.alloc(offset + borsh.byteSize + offset)
-        borsh.write(buf, offset, x)
-        const n = borsh.read(buf, offset)
+        const buf = Buffer.alloc(offset + beet.byteSize + offset)
+        beet.write(buf, offset, x)
+        const n = beet.read(buf, offset)
         const [a, b] = oneType(x, n)
         t.equal(
           a.toString(),
@@ -49,9 +49,9 @@ function checkCases(
       }
       {
         // Exact buffer
-        const buf = Buffer.alloc(offset + borsh.byteSize)
-        borsh.write(buf, offset, x)
-        const n = borsh.read(buf, offset)
+        const buf = Buffer.alloc(offset + beet.byteSize)
+        beet.write(buf, offset, x)
+        const n = beet.read(buf, offset)
         const [a, b] = oneType(x, n)
         t.equal(
           a.toString(),
@@ -69,36 +69,36 @@ function checkCases(
 test('numbers: round trip u8', (t) => {
   const cases = [0, 1, 100, 0xff]
   const offsets = [0, u8.byteSize, 2 * u8.byteSize]
-  const borsh = u8
+  const beet = u8
 
-  checkCases(offsets, cases, borsh, t)
+  checkCases(offsets, cases, beet, t)
   t.end()
 })
 
 test('numbers: round trip u16', (t) => {
   const cases = [0, 1, 0xff, 0xffff]
   const offsets = [0, u16.byteSize, 2 * u16.byteSize]
-  const borsh = u16
+  const beet = u16
 
-  checkCases(offsets, cases, borsh, t)
+  checkCases(offsets, cases, beet, t)
   t.end()
 })
 
 test('numbers: round trip u32', (t) => {
   const cases = [0, 0xff, 0xffff, 0xffffffff]
   const offsets = [0, u32.byteSize, 2 * u32.byteSize]
-  const borsh = u32
+  const beet = u32
 
-  checkCases(offsets, cases, borsh, t)
+  checkCases(offsets, cases, beet, t)
   t.end()
 })
 
 test('numbers: round trip u64', (t) => {
   const cases = [0, 0xff, 0xffff, 0xffffffff, new BN('18446744073709551615')]
   const offsets = [0, u64.byteSize, 2 * u64.byteSize]
-  const borsh = u64
+  const beet = u64
 
-  checkCases(offsets, cases, borsh, t)
+  checkCases(offsets, cases, beet, t)
   t.end()
 })
 
@@ -112,9 +112,9 @@ test('numbers: round trip u128', (t) => {
     new BN('340282366920938463463374607431768211455'),
   ]
   const offsets = [0, u128.byteSize, 2 * u128.byteSize]
-  const borsh = u128
+  const beet = u128
 
-  checkCases(offsets, cases, borsh, t)
+  checkCases(offsets, cases, beet, t)
   t.end()
 })
 
@@ -131,9 +131,9 @@ test('numbers: round trip u256', (t) => {
     ),
   ]
   const offsets = [0, u256.byteSize, 2 * u256.byteSize]
-  const borsh = u256
+  const beet = u256
 
-  checkCases(offsets, cases, borsh, t)
+  checkCases(offsets, cases, beet, t)
   t.end()
 })
 
@@ -153,9 +153,9 @@ test('numbers: round trip u512', (t) => {
     ),
   ]
   const offsets = [0, u512.byteSize, 2 * u512.byteSize]
-  const borsh = u512
+  const beet = u512
 
-  checkCases(offsets, cases, borsh, t)
+  checkCases(offsets, cases, beet, t)
   t.end()
 })
 
@@ -163,28 +163,28 @@ test('numbers: round trip u512', (t) => {
 // Signed Ints
 // -----------------
 test('numbers: round trip i8', (t) => {
-  const borsh = i8
+  const beet = i8
   const cases = [0, 1, -1, 100, -100, 0x7f, -0x80]
-  const offsets = [0, borsh.byteSize, 2 * borsh.byteSize]
+  const offsets = [0, beet.byteSize, 2 * beet.byteSize]
 
-  checkCases(offsets, cases, borsh, t)
+  checkCases(offsets, cases, beet, t)
   t.end()
 })
 
 test('numbers: round trip i16', (t) => {
-  const borsh = i16
+  const beet = i16
   const cases = [0, 1, -1, 0x7f, -0x80, 0x7fff, -0x8000]
-  const offsets = [0, borsh.byteSize, 2 * borsh.byteSize]
+  const offsets = [0, beet.byteSize, 2 * beet.byteSize]
 
-  checkCases(offsets, cases, borsh, t)
+  checkCases(offsets, cases, beet, t)
   t.end()
 })
 
 test('numbers: round trip i32', (t) => {
-  const borsh = i32
+  const beet = i32
   const cases = [0, 1, -1, 0x7f, -0x80, 0x7fff, -0x8000, 0x7fffff, -0x800000]
-  const offsets = [0, borsh.byteSize, 2 * borsh.byteSize]
+  const offsets = [0, beet.byteSize, 2 * beet.byteSize]
 
-  checkCases(offsets, cases, borsh, t)
+  checkCases(offsets, cases, beet, t)
   t.end()
 })

--- a/test/structs.ts
+++ b/test/structs.ts
@@ -1,7 +1,7 @@
 import BN from 'bn.js'
 import test from 'tape'
 import spok, { Specifications } from 'spok'
-import { BorshStruct, i32, u128, u16, u8 } from '../src/borsh'
+import { BeetStruct, i32, u128, u16, u8 } from '../src/beet'
 
 class GameScore {
   constructor(
@@ -11,7 +11,7 @@ class GameScore {
     readonly losses: number
   ) {}
 
-  static readonly struct = new BorshStruct<GameScore>(
+  static readonly struct = new BeetStruct<GameScore>(
     [
       ['win', u8],
       ['totalWin', u16],


### PR DESCRIPTION
This version of Borsh is more limited/strict than the _official_ Borsh.

It requires each data type that is de/serializable to have a fixed size. This allows
calculating sizes when composing a data type of multiple other data types as well as providing
more detailed error messages + checks as the desired size is explicit.

Thus it is a more rigid version of _Borsh_ and thus _Beet_

## Beet

![](https://d2jx2rerrg6sh3.cloudfront.net/image-handler/ts/20211020125312/ri/673/picture/2021/10/shutterstock_374278960.jpg)

## Borsh

![](https://www.willcookforsmiles.com/wp-content/uploads/2018/10/Russian-Borscht.jpg)
