### PR TITLE
feat: dynamic types via length specifiers

### DIFF
--- a/beet-solana/src/keys.ts
+++ b/beet-solana/src/keys.ts
@@ -1,6 +1,6 @@
 import { PublicKey } from '@solana/web3.js'
 import {
-  Beet,
+  FixedSizeBeet,
   fixedSizeUint8Array,
   SupportedTypeDefinition,
 } from '@metaplex-foundation/beet'
@@ -43,7 +43,7 @@ const uint8Array32 = fixedSizeUint8Array(32)
  *
  * @category beet/solana
  */
-export const publicKey: Beet<PublicKey> = {
+export const publicKey: FixedSizeBeet<PublicKey> = {
   write: function (buf: Buffer, offset: number, value: PublicKey): void {
     const arr = value.toBytes()
     uint8Array32.write(buf, offset, arr)

--- a/beet-solana/test/keys.public.ts
+++ b/beet-solana/test/keys.public.ts
@@ -1,4 +1,4 @@
-import { Beet } from '@metaplex-foundation/beet'
+import { FixedSizeBeet } from '@metaplex-foundation/beet'
 import { PublicKey, Keypair } from '@solana/web3.js'
 import { publicKey } from '../src/beet-solana'
 import test from 'tape'
@@ -6,7 +6,7 @@ import test from 'tape'
 function checkCases(
   offsets: number[],
   cases: PublicKey[],
-  beet: Beet<PublicKey>,
+  beet: FixedSizeBeet<PublicKey>,
   t: test.Test
 ) {
   for (const offset of offsets) {

--- a/beet/src/beet.dynamic.ts
+++ b/beet/src/beet.dynamic.ts
@@ -1,0 +1,74 @@
+import {
+  assertFixedSizeBeet,
+  Beet,
+  DynamicSizeCompositeBeet,
+  FixedSizeBeet,
+  FixedSizeCompositeBeet,
+  isCompositeBeet,
+  isDynamicSizeBeet,
+  isDynamicSizeCompositeBeet,
+} from './types'
+import { fixedSizeArray } from './beets/collections'
+import { strict as assert } from 'assert'
+
+/**
+ * Resolves all contained dymanic size beets to a static version using the
+ * provided lens.
+ *
+ */
+export function toFixed<T, V = T>(
+  beet: Beet<T, V>,
+  lens: number[]
+): FixedSizeBeet<T, V> {
+  if (isCompositeBeet(beet)) {
+    // Handle inner beets first, i.e. make them fixed inside out
+    const inner = toFixed(beet.inner, lens)
+    const withFixedInner = beet.withFixedSizeInner(inner)
+
+    if (isDynamicSizeCompositeBeet(withFixedInner)) {
+      // @ts-ignore
+      return withFixedInner.toFixed(lens.pop())
+    }
+
+    assertFixedSizeBeet(withFixedInner)
+
+    return withFixedInner
+  }
+  // Non Composites
+  if (isDynamicSizeBeet(beet)) {
+    const len = lens.pop()
+    assert(
+      len != null,
+      `Should provide enough 'lens', ran out for ${beet.description}`
+    )
+    return beet.toFixed(len)
+  }
+  assertFixedSizeBeet(beet)
+
+  return beet
+}
+
+export function dynamicSizeArray<T>(
+  element: Beet<T>
+): DynamicSizeCompositeBeet<T[], T> {
+  return {
+    // @ts-ignore
+    withFixedSizeInner(
+      fixedInner: FixedSizeBeet<T>
+    ): DynamicSizeCompositeBeet<T[], T> {
+      return dynamicSizeArray(fixedInner)
+    },
+
+    // @ts-ignore
+    get inner() {
+      return element
+    },
+
+    // @ts-ignore
+    toFixed(len: number): FixedSizeCompositeBeet<T[], T> {
+      // @ts-ignore
+      return fixedSizeArray(element, len, true)
+    },
+    description: `DynamicArray<${element.description}>`,
+  }
+}

--- a/beet/src/beet.dynamic.ts
+++ b/beet/src/beet.dynamic.ts
@@ -7,7 +7,7 @@ import {
   isCompositeBeet,
   isDynamicSizeBeet,
 } from './types'
-import { fixedSizeArray } from './beets/collections'
+import { fixedSizeArray, fixedSizeUtf8String } from './beets/collections'
 import { strict as assert } from 'assert'
 
 /**
@@ -51,6 +51,15 @@ export function toFixed<T, V = T>(
   return beet
 }
 
+/**
+ * De/Serializes an array with a dynamic number of elements of type {@link T}.
+ *
+ * @template T type of elements held in the array
+ *
+ * @param element the De/Serializer for the element type
+ *
+ * @category beet/collection
+ */
 export function dynamicSizeArray<T, V = Partial<T>>(
   element: Beet<T, V>
 ): Collection<T[], V[]> & DynamicSizeBeet<T[], V[]> {
@@ -59,7 +68,6 @@ export function dynamicSizeArray<T, V = Partial<T>>(
       return element
     },
 
-    // @ts-ignore
     withFixedSizeInner(fixedInner: FixedSizeBeet<T>) {
       return dynamicSizeArray(fixedInner)
     },
@@ -73,5 +81,19 @@ export function dynamicSizeArray<T, V = Partial<T>>(
     },
 
     description: `DynamicArray<${element.description}>`,
+  }
+}
+
+/**
+ * De/Serializes a UTF8 string of dynamic size.
+ *
+ * @category beet/collection
+ */
+export function dynamicSizeUtf8String(): DynamicSizeBeet<string> {
+  return {
+    toFixed(len: number): FixedSizeBeet<string> {
+      return fixedSizeUtf8String(len)
+    },
+    description: 'Utf8String',
   }
 }

--- a/beet/src/beet.dynamic.ts
+++ b/beet/src/beet.dynamic.ts
@@ -23,14 +23,7 @@ export function toFixed<T, V = T>(
   structMaps: Map<string, number[]>[] = []
 ): FixedSizeBeet<T, V> {
   if (isDynamicSizeBeetStruct(beet)) {
-    const map = structMaps.pop()
-    assert(
-      map != null,
-      `Missing struct entry for ${beet.description}, inside ${structMaps}`
-    )
-    // TODO(thlorenz): How can we verify this is really Map<keyof V, number[]>?
-    // (most likely via beet.fields)
-    return beet.toFixedFromMap(map as Map<keyof V, number[]>)
+    return beet.toFixedFromMap(beetLengths, structMaps)
   }
 
   if (isCompositeBeet(beet)) {

--- a/beet/src/beet.ts
+++ b/beet/src/beet.ts
@@ -9,7 +9,11 @@ import {
   compositesTypeMap,
   CompositesTypeMapKey,
 } from './beets/composites'
-import { NumbersExports, numbersTypeMap, NumbersTypeMapKey } from './beets/numbers'
+import {
+  NumbersExports,
+  numbersTypeMap,
+  NumbersTypeMapKey,
+} from './beets/numbers'
 
 export * from './beets/collections'
 export * from './beets/composites'

--- a/beet/src/beet.ts
+++ b/beet/src/beet.ts
@@ -1,24 +1,21 @@
-import { Beet, BeetField, SupportedTypeDefinition } from './types'
-import { strict as assert } from 'assert'
-import colors from 'ansicolors'
-import { logDebug, logTrace } from './utils'
+import { SupportedTypeDefinition } from './types'
 import {
   CollectionsExports,
   collectionsTypeMap,
   CollectionsTypeMapKey,
-} from './collections'
+} from './beets/collections'
 import {
   CompositesExports,
   compositesTypeMap,
   CompositesTypeMapKey,
-} from './composites'
-import { NumbersExports, numbersTypeMap, NumbersTypeMapKey } from './numbers'
+} from './beets/composites'
+import { NumbersExports, numbersTypeMap, NumbersTypeMapKey } from './beets/numbers'
 
-const { brightBlack } = colors
-
-export * from './collections'
-export * from './composites'
-export * from './numbers'
+export * from './beets/collections'
+export * from './beets/composites'
+export * from './beets/numbers'
+export * from './read-write'
+export * from './struct'
 export * from './types'
 
 /**
@@ -53,211 +50,4 @@ export const supportedTypeMap: Record<
   ...collectionsTypeMap,
   ...compositesTypeMap,
   ...numbersTypeMap,
-}
-
-// -----------------
-// Writer
-// -----------------
-/**
- * Underlying writer used to serialize structs.
- *
- * @private
- * @category beet/struct
- */
-export class BeetWriter {
-  private buf: Buffer
-  private _offset: number
-  constructor(byteSize: number) {
-    this.buf = Buffer.alloc(byteSize)
-    this._offset = 0
-  }
-
-  get buffer() {
-    return this.buf
-  }
-
-  get offset() {
-    return this._offset
-  }
-
-  private maybeResize(bytesNeeded: number) {
-    if (this._offset + bytesNeeded > this.buf.length) {
-      assert.fail(
-        `We shouldn't ever need to resize, but ${
-          this._offset + bytesNeeded
-        } > ${this.buf.length}`
-      )
-      // this.buf = Buffer.concat([this.buf, Buffer.alloc(this.allocateBytes)])
-    }
-  }
-
-  write<T>(beet: Beet<T>, value: T) {
-    this.maybeResize(beet.byteSize)
-    beet.write(this.buf, this._offset, value)
-    this._offset += beet.byteSize
-  }
-
-  writeStruct<T>(instance: T, fields: BeetField<T>[]) {
-    for (const [key, beet] of fields) {
-      const value = instance[key]
-      this.write(beet, value)
-    }
-  }
-}
-
-// -----------------
-// Reader
-// -----------------
-/**
- * Underlying reader used to deserialize structs.
- *
- * @private
- * @category beet/struct
- */
-export class BeetReader {
-  constructor(private readonly buffer: Buffer, private _offset: number = 0) {}
-
-  get offset() {
-    return this._offset
-  }
-
-  read<T>(beet: Beet<T>): T {
-    const value = beet.read(this.buffer, this._offset)
-    this._offset += beet.byteSize
-    return value
-  }
-
-  readStruct<T>(fields: BeetField<T>[]) {
-    const acc: T = <T>{}
-    for (const [key, beet] of fields) {
-      acc[key] = this.read(beet)
-    }
-    return acc
-  }
-}
-
-function bytes(val: { byteSize: number }) {
-  return brightBlack(`${val.byteSize} B`)
-}
-
-/**
- * Configures a class or any JavaScript object type for de/serialization aka
- * read/write.
- *
- * @template Class the type to produce when deserializing
- * @template Args contains all fields, is typically a subset of Class and is
- * used to construct an instance of it
- *
- * @category beet/struct
- */
-export class BeetStruct<Class, Args = Partial<Class>> implements Beet<Class> {
-  readonly byteSize: number
-  /**
-   * Creates an instance of the BeetStruct.
-   *
-   * @param fields de/serializers for each field of the {@link Class}
-   * @param construct the function that creates an instance of {@link Class}
-   * from the args
-   * @param description identifies this struct for diagnostics/debugging
-   * purposes
-   */
-  constructor(
-    private readonly fields: BeetField<Args>[],
-    private readonly construct: (args: Args) => Class,
-    readonly description = BeetStruct.description
-  ) {
-    this.byteSize = this.getByteSize()
-    if (logDebug.enabled) {
-      const flds = fields
-        .map(
-          ([key, val]: BeetField<Args>) =>
-            `${key}: ${val.description} ${bytes(val)}`
-        )
-        .join('\n  ')
-      logDebug(`struct ${description} {\n  ${flds}\n} ${bytes(this)}`)
-    }
-  }
-
-  /**
-   * Along with `write` this allows structs to be treated as {@link Beet}s and
-   * thus supports composing/nesting them the same way.
-   * @private
-   */
-  read(buf: Buffer, offset: number): Class {
-    const [value] = this.deserialize(buf, offset)
-    return value
-  }
-
-  /**
-   * Along with `read` this allows structs to be treated as {@link Beet}s and
-   * thus supports composing/nesting them the same way.
-   * @private
-   */
-  write(buf: Buffer, offset: number, value: Args): void {
-    const [innerBuf, innerOffset] = this.serialize(value)
-    innerBuf.copy(buf, offset, 0, innerOffset)
-  }
-
-  /**
-   * Deserializes an instance of the Class from the provided buffer starting to
-   * read at the provided offset.
-   *
-   * @returns `[instance of Class, offset into buffer after deserialization completed]`
-   */
-  deserialize(buffer: Buffer, offset: number = 0): [Class, number] {
-    if (logTrace.enabled) {
-      logTrace(
-        'deserializing [%s] from %d bytes buffer',
-        this.description,
-        buffer.byteLength
-      )
-      logTrace(buffer)
-      logTrace(buffer.toJSON().data)
-    }
-    const reader = new BeetReader(buffer, offset)
-    const args = reader.readStruct(this.fields)
-    return [this.construct(args), reader.offset]
-  }
-
-  /**
-   * Serializes the provided instance into a new {@link Buffer}
-   *
-   * @param instance of the struct to serialize
-   * @param byteSize allows to override the size fo the created Buffer and
-   * defaults to the size of the struct to serialize
-   */
-  serialize(instance: Args, byteSize = this.byteSize): [Buffer, number] {
-    logTrace(
-      'serializing [%s] %o to %d bytes buffer',
-      this.description,
-      instance,
-      this.byteSize
-    )
-    const writer = new BeetWriter(byteSize)
-    writer.writeStruct(instance, this.fields)
-    return [writer.buffer, writer.offset]
-  }
-
-  private getByteSize() {
-    return this.fields.reduce((acc, [_, beet]) => acc + beet.byteSize, 0)
-  }
-
-  static description = 'BeetStruct'
-}
-
-/**
- * Convenience wrapper around {@link BeetStruct} which is used for plain JavasScript
- * objects, like are used for option args passed to functions.
- *
- * @category beet/struct
- */
-export class BeetArgsStruct<Args> extends BeetStruct<Args, Args> {
-  constructor(
-    fields: BeetField<Args>[],
-    description: string = BeetArgsStruct.description
-  ) {
-    super(fields, (args) => args, description)
-  }
-
-  static description = 'BeetArgsStruct'
 }

--- a/beet/src/beets/collections.ts
+++ b/beet/src/beets/collections.ts
@@ -1,7 +1,7 @@
-import { Beet, BEET_TYPE_ARG_LEN, SupportedTypeDefinition } from './types'
+import { Beet, BEET_TYPE_ARG_LEN, SupportedTypeDefinition } from '../types'
 import { strict as assert } from 'assert'
 import { u32 } from './numbers'
-import { BEET_PACKAGE } from './types'
+import { BEET_PACKAGE } from '../types'
 
 /**
  * De/Serializes a UTF8 string of a particular size.

--- a/beet/src/beets/collections.ts
+++ b/beet/src/beets/collections.ts
@@ -36,6 +36,9 @@ export const fixedSizeUtf8String: (
       const stringSlice = buf.slice(offset + 4, offset + 4 + stringByteLength)
       return stringSlice.toString('utf8')
     },
+    elementByteSize: 1,
+    len: stringByteLength,
+    lenPrefixByteSize: 4,
     byteSize: 4 + stringByteLength,
     description: `Utf8String(${stringByteLength})`,
   }
@@ -91,6 +94,7 @@ export function fixedSizeArray<T, V = Partial<T>>(
       return arr
     },
     byteSize,
+    lenPrefixByteSize: 4,
     description: `Array<${element.description}>(${len})`,
 
     // Composite

--- a/beet/src/beets/collections.ts
+++ b/beet/src/beets/collections.ts
@@ -1,7 +1,7 @@
 import {
-  StaticBeetCollection,
+  FixedBeetCollection,
   BEET_TYPE_ARG_LEN,
-  StaticBeet,
+  FixedBeet,
   SupportedTypeDefinition,
 } from '../types'
 import { strict as assert } from 'assert'
@@ -17,7 +17,7 @@ import { BEET_PACKAGE } from '../types'
  */
 export const fixedSizeUtf8String: (
   stringByteLength: number
-) => StaticBeet<string> = (stringByteLength: number) => {
+) => FixedBeet<string> = (stringByteLength: number) => {
   return {
     write: function (buf: Buffer, offset: number, value: string) {
       const stringBuf = Buffer.from(value, 'utf8')
@@ -54,10 +54,10 @@ export const fixedSizeUtf8String: (
  * @category beet/collection
  */
 export function fixedSizeArray<T>(
-  element: StaticBeet<T>,
+  element: FixedBeet<T>,
   len: number,
   lenPrefix: boolean = false
-): StaticBeetCollection<T> {
+): FixedBeetCollection<T> {
   const arraySize = element.byteSize * len
   const byteSize = lenPrefix ? 4 + arraySize : arraySize
 
@@ -101,7 +101,7 @@ export function fixedSizeArray<T>(
  * @param bytes the byte size of the buffer to de/serialize
  * @category beet/collection
  */
-export function fixedSizeBuffer(bytes: number): StaticBeet<Buffer> {
+export function fixedSizeBuffer(bytes: number): FixedBeet<Buffer> {
   return {
     write: function (buf: Buffer, offset: number, value: Buffer): void {
       value.copy(buf, offset, 0, bytes)
@@ -121,7 +121,7 @@ export function fixedSizeBuffer(bytes: number): StaticBeet<Buffer> {
  *
  * @category beet/collection
  */
-export function fixedSizeUint8Array(len: number): StaticBeet<Uint8Array> {
+export function fixedSizeUint8Array(len: number): FixedBeet<Uint8Array> {
   const arrayBufferBeet = fixedSizeBuffer(len)
   return {
     write: function (buf: Buffer, offset: number, value: Uint8Array): void {

--- a/beet/src/beets/collections.ts
+++ b/beet/src/beets/collections.ts
@@ -37,7 +37,7 @@ export const fixedSizeUtf8String: (
       return stringSlice.toString('utf8')
     },
     byteSize: 4 + stringByteLength,
-    description: `utf8-string(${stringByteLength})`,
+    description: `Utf8String(${stringByteLength})`,
   }
 }
 

--- a/beet/src/beets/collections.ts
+++ b/beet/src/beets/collections.ts
@@ -3,6 +3,7 @@ import {
   FixedSizeBeet,
   SupportedTypeDefinition,
   Collection,
+  ElementCollectionBeet,
 } from '../types'
 import { strict as assert } from 'assert'
 import { u32 } from './numbers'
@@ -60,7 +61,7 @@ export function fixedSizeArray<T, V = Partial<T>>(
   element: FixedSizeBeet<T, V>,
   len: number,
   lenPrefix: boolean = false
-): Collection<T[], V[]> & FixedSizeBeet<T[], V[]> {
+): Collection<T[], V[]> & ElementCollectionBeet & FixedSizeBeet<T[], V[]> {
   const arraySize = element.byteSize * len
   const byteSize = lenPrefix ? 4 + arraySize : arraySize
 
@@ -94,6 +95,8 @@ export function fixedSizeArray<T, V = Partial<T>>(
       return arr
     },
     byteSize,
+    len,
+    elementByteSize: element.byteSize,
     lenPrefixByteSize: 4,
     description: `Array<${element.description}>(${len})`,
 

--- a/beet/src/beets/collections.ts
+++ b/beet/src/beets/collections.ts
@@ -1,4 +1,9 @@
-import { Beet, BEET_TYPE_ARG_LEN, SupportedTypeDefinition } from '../types'
+import {
+  StaticBeetCollection,
+  BEET_TYPE_ARG_LEN,
+  StaticBeet,
+  SupportedTypeDefinition,
+} from '../types'
 import { strict as assert } from 'assert'
 import { u32 } from './numbers'
 import { BEET_PACKAGE } from '../types'
@@ -10,9 +15,9 @@ import { BEET_PACKAGE } from '../types'
  *
  * @category beet/collection
  */
-export const fixedSizeUtf8String: (stringByteLength: number) => Beet<string> = (
+export const fixedSizeUtf8String: (
   stringByteLength: number
-) => {
+) => StaticBeet<string> = (stringByteLength: number) => {
   return {
     write: function (buf: Buffer, offset: number, value: string) {
       const stringBuf = Buffer.from(value, 'utf8')
@@ -49,10 +54,10 @@ export const fixedSizeUtf8String: (stringByteLength: number) => Beet<string> = (
  * @category beet/collection
  */
 export function fixedSizeArray<T>(
-  element: Beet<T>,
+  element: StaticBeet<T>,
   len: number,
   lenPrefix: boolean = false
-): Beet<T[]> {
+): StaticBeetCollection<T> {
   const arraySize = element.byteSize * len
   const byteSize = lenPrefix ? 4 + arraySize : arraySize
 
@@ -85,10 +90,10 @@ export function fixedSizeArray<T>(
       return arr
     },
     byteSize,
+    element,
     description: `Array<${element.description}>(${len})`,
   }
 }
-
 /**
  * A De/Serializer for raw {@link Buffer}s that just copies/reads the buffer bytes
  * to/from the provided buffer.
@@ -96,7 +101,7 @@ export function fixedSizeArray<T>(
  * @param bytes the byte size of the buffer to de/serialize
  * @category beet/collection
  */
-export function fixedSizeBuffer(bytes: number): Beet<Buffer> {
+export function fixedSizeBuffer(bytes: number): StaticBeet<Buffer> {
   return {
     write: function (buf: Buffer, offset: number, value: Buffer): void {
       value.copy(buf, offset, 0, bytes)
@@ -116,7 +121,7 @@ export function fixedSizeBuffer(bytes: number): Beet<Buffer> {
  *
  * @category beet/collection
  */
-export function fixedSizeUint8Array(len: number): Beet<Uint8Array> {
+export function fixedSizeUint8Array(len: number): StaticBeet<Uint8Array> {
   const arrayBufferBeet = fixedSizeBuffer(len)
   return {
     write: function (buf: Buffer, offset: number, value: Uint8Array): void {

--- a/beet/src/beets/composites.ts
+++ b/beet/src/beets/composites.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert'
 import { u8 } from './numbers'
-import { Beet, BEET_TYPE_ARG_INNER, SupportedTypeDefinition } from './types'
-import { BEET_PACKAGE } from './types'
+import { Beet, BEET_TYPE_ARG_INNER, SupportedTypeDefinition } from '../types'
+import { BEET_PACKAGE } from '../types'
 
 /**
  * Represents the Rust Option type {@link T}.

--- a/beet/src/beets/composites.ts
+++ b/beet/src/beets/composites.ts
@@ -1,6 +1,10 @@
 import { strict as assert } from 'assert'
 import { u8 } from './numbers'
-import { Beet, BEET_TYPE_ARG_INNER, SupportedTypeDefinition } from '../types'
+import {
+  BEET_TYPE_ARG_INNER,
+  StaticBeet,
+  SupportedTypeDefinition,
+} from '../types'
 import { BEET_PACKAGE } from '../types'
 
 /**
@@ -27,7 +31,7 @@ const NONE = Buffer.from(Uint8Array.from([0, 0, 0, 0])).slice(0, 4)
  *
  * @category beet/composite
  */
-export function coption<T>(inner: Beet<T>): Beet<COption<T>> {
+export function coption<T>(inner: StaticBeet<T>): StaticBeet<COption<T>> {
   return {
     write: function (buf: Buffer, offset: number, value: COption<T>) {
       if (value == null) {
@@ -77,8 +81,8 @@ export type DataEnum<Kind, Data> = { kind: Kind & number; data: Data }
  * @category beet/composite
  */
 export function dataEnum<Kind, Data>(
-  inner: Beet<Data>
-): Beet<DataEnum<Kind, Data>> {
+  inner: StaticBeet<Data>
+): StaticBeet<DataEnum<Kind, Data>> {
   return {
     write: function (buf: Buffer, offset: number, value: DataEnum<Kind, Data>) {
       u8.write(buf, offset, value.kind)

--- a/beet/src/beets/composites.ts
+++ b/beet/src/beets/composites.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert'
 import { u8 } from './numbers'
 import {
   BEET_TYPE_ARG_INNER,
-  StaticBeet,
+  FixedBeet,
   SupportedTypeDefinition,
 } from '../types'
 import { BEET_PACKAGE } from '../types'
@@ -31,7 +31,7 @@ const NONE = Buffer.from(Uint8Array.from([0, 0, 0, 0])).slice(0, 4)
  *
  * @category beet/composite
  */
-export function coption<T>(inner: StaticBeet<T>): StaticBeet<COption<T>> {
+export function coption<T>(inner: FixedBeet<T>): FixedBeet<COption<T>> {
   return {
     write: function (buf: Buffer, offset: number, value: COption<T>) {
       if (value == null) {
@@ -81,8 +81,8 @@ export type DataEnum<Kind, Data> = { kind: Kind & number; data: Data }
  * @category beet/composite
  */
 export function dataEnum<Kind, Data>(
-  inner: StaticBeet<Data>
-): StaticBeet<DataEnum<Kind, Data>> {
+  inner: FixedBeet<Data>
+): FixedBeet<DataEnum<Kind, Data>> {
   return {
     write: function (buf: Buffer, offset: number, value: DataEnum<Kind, Data>) {
       u8.write(buf, offset, value.kind)

--- a/beet/src/beets/numbers.ts
+++ b/beet/src/beets/numbers.ts
@@ -1,5 +1,5 @@
 import BN from 'bn.js'
-import { bignum, SupportedTypeDefinition, StaticBeet } from '../types'
+import { bignum, SupportedTypeDefinition, FixedBeet } from '../types'
 import { BEET_PACKAGE } from '../types'
 
 // -----------------
@@ -11,7 +11,7 @@ import { BEET_PACKAGE } from '../types'
  *
  * @category beet/primitive
  */
-export const u8: StaticBeet<number> = {
+export const u8: FixedBeet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeUInt8(value, offset)
   },
@@ -27,7 +27,7 @@ export const u8: StaticBeet<number> = {
  *
  * @category beet/primitive
  */
-export const u16: StaticBeet<number> = {
+export const u16: FixedBeet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeUInt16LE(value, offset)
   },
@@ -43,7 +43,7 @@ export const u16: StaticBeet<number> = {
  *
  * @category beet/primitive
  */
-export const u32: StaticBeet<number> = {
+export const u32: FixedBeet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeUInt32LE(value, offset)
   },
@@ -77,28 +77,28 @@ function unsignedLargeBeet(byteSize: number, description: string) {
  *
  * @category beet/primitive
  */
-export const u64: StaticBeet<bignum> = unsignedLargeBeet(8, 'u64')
+export const u64: FixedBeet<bignum> = unsignedLargeBeet(8, 'u64')
 /**
  * De/Serializer for 128-bit unsigned integers aka `u128` which serializes to a JavaScript
  * _BigNum_ via {@link https://github.com/indutny/bn.js | BN}.
  *
  * @category beet/primitive
  */
-export const u128: StaticBeet<bignum> = unsignedLargeBeet(16, 'u128')
+export const u128: FixedBeet<bignum> = unsignedLargeBeet(16, 'u128')
 /**
  * De/Serializer for 256-bit unsigned integers aka `u256` which serializes to a JavaScript
  * _BigNum_ via {@link https://github.com/indutny/bn.js | BN}.
  *
  * @category beet/primitive
  */
-export const u256: StaticBeet<bignum> = unsignedLargeBeet(32, 'u256')
+export const u256: FixedBeet<bignum> = unsignedLargeBeet(32, 'u256')
 /**
  * De/Serializer for 512-bit unsigned integers aka `u512` which serializes to a JavaScript
  * _BigNum_ via {@link https://github.com/indutny/bn.js | BN}.
  *
  * @category beet/primitive
  */
-export const u512: StaticBeet<bignum> = unsignedLargeBeet(64, 'u512')
+export const u512: FixedBeet<bignum> = unsignedLargeBeet(64, 'u512')
 
 // -----------------
 // Signed
@@ -108,7 +108,7 @@ export const u512: StaticBeet<bignum> = unsignedLargeBeet(64, 'u512')
  *
  * @category beet/primitive
  */
-export const i8: StaticBeet<number> = {
+export const i8: FixedBeet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeInt8(value, offset)
   },
@@ -124,7 +124,7 @@ export const i8: StaticBeet<number> = {
  *
  * @category beet/primitive
  */
-export const i16: StaticBeet<number> = {
+export const i16: FixedBeet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeInt16LE(value, offset)
   },
@@ -140,7 +140,7 @@ export const i16: StaticBeet<number> = {
  *
  * @category beet/primitive
  */
-export const i32: StaticBeet<number> = {
+export const i32: FixedBeet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeInt32LE(value, offset)
   },
@@ -176,28 +176,28 @@ function signedLargeBeet(byteSize: number, description: string) {
  *
  * @category beet/primitive
  */
-export const i64: StaticBeet<bignum> = signedLargeBeet(8, 'i64')
+export const i64: FixedBeet<bignum> = signedLargeBeet(8, 'i64')
 /**
  * De/Serializer for 128-bit signed integers aka `i128` which serializes to a JavaScript
  * _BigNum_ via {@link https://github.com/indutny/bn.js | BN}.
  *
  * @category beet/primitive
  */
-export const i128: StaticBeet<bignum> = signedLargeBeet(16, 'i128')
+export const i128: FixedBeet<bignum> = signedLargeBeet(16, 'i128')
 /**
  * De/Serializer for 256-bit signed integers aka `i256` which serializes to a JavaScript
  * _BigNum_ via {@link https://github.com/indutny/bn.js | BN}.
  *
  * @category beet/primitive
  */
-export const i256: StaticBeet<bignum> = signedLargeBeet(32, 'i256')
+export const i256: FixedBeet<bignum> = signedLargeBeet(32, 'i256')
 /**
  * De/Serializer for 512-bit signed integers aka `i512` which serializes to a JavaScript
  * _BigNum_ via {@link https://github.com/indutny/bn.js | BN}.
  *
  * @category beet/primitive
  */
-export const i512: StaticBeet<bignum> = signedLargeBeet(64, 'i512')
+export const i512: FixedBeet<bignum> = signedLargeBeet(64, 'i512')
 
 // -----------------
 // Boolean
@@ -207,7 +207,7 @@ export const i512: StaticBeet<bignum> = signedLargeBeet(64, 'i512')
  *
  * @category beet/primitive
  */
-export const bool: StaticBeet<boolean> = {
+export const bool: FixedBeet<boolean> = {
   write: function (buf: Buffer, offset: number, value: boolean): void {
     const n = value ? 1 : 0
     u8.write(buf, offset, n)

--- a/beet/src/beets/numbers.ts
+++ b/beet/src/beets/numbers.ts
@@ -1,5 +1,5 @@
 import BN from 'bn.js'
-import { bignum, SupportedTypeDefinition, FixedBeet } from '../types'
+import { bignum, SupportedTypeDefinition, FixedSizeBeet } from '../types'
 import { BEET_PACKAGE } from '../types'
 
 // -----------------
@@ -11,7 +11,7 @@ import { BEET_PACKAGE } from '../types'
  *
  * @category beet/primitive
  */
-export const u8: FixedBeet<number> = {
+export const u8: FixedSizeBeet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeUInt8(value, offset)
   },
@@ -27,7 +27,7 @@ export const u8: FixedBeet<number> = {
  *
  * @category beet/primitive
  */
-export const u16: FixedBeet<number> = {
+export const u16: FixedSizeBeet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeUInt16LE(value, offset)
   },
@@ -43,7 +43,7 @@ export const u16: FixedBeet<number> = {
  *
  * @category beet/primitive
  */
-export const u32: FixedBeet<number> = {
+export const u32: FixedSizeBeet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeUInt32LE(value, offset)
   },
@@ -77,28 +77,28 @@ function unsignedLargeBeet(byteSize: number, description: string) {
  *
  * @category beet/primitive
  */
-export const u64: FixedBeet<bignum> = unsignedLargeBeet(8, 'u64')
+export const u64: FixedSizeBeet<bignum> = unsignedLargeBeet(8, 'u64')
 /**
  * De/Serializer for 128-bit unsigned integers aka `u128` which serializes to a JavaScript
  * _BigNum_ via {@link https://github.com/indutny/bn.js | BN}.
  *
  * @category beet/primitive
  */
-export const u128: FixedBeet<bignum> = unsignedLargeBeet(16, 'u128')
+export const u128: FixedSizeBeet<bignum> = unsignedLargeBeet(16, 'u128')
 /**
  * De/Serializer for 256-bit unsigned integers aka `u256` which serializes to a JavaScript
  * _BigNum_ via {@link https://github.com/indutny/bn.js | BN}.
  *
  * @category beet/primitive
  */
-export const u256: FixedBeet<bignum> = unsignedLargeBeet(32, 'u256')
+export const u256: FixedSizeBeet<bignum> = unsignedLargeBeet(32, 'u256')
 /**
  * De/Serializer for 512-bit unsigned integers aka `u512` which serializes to a JavaScript
  * _BigNum_ via {@link https://github.com/indutny/bn.js | BN}.
  *
  * @category beet/primitive
  */
-export const u512: FixedBeet<bignum> = unsignedLargeBeet(64, 'u512')
+export const u512: FixedSizeBeet<bignum> = unsignedLargeBeet(64, 'u512')
 
 // -----------------
 // Signed
@@ -108,7 +108,7 @@ export const u512: FixedBeet<bignum> = unsignedLargeBeet(64, 'u512')
  *
  * @category beet/primitive
  */
-export const i8: FixedBeet<number> = {
+export const i8: FixedSizeBeet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeInt8(value, offset)
   },
@@ -124,7 +124,7 @@ export const i8: FixedBeet<number> = {
  *
  * @category beet/primitive
  */
-export const i16: FixedBeet<number> = {
+export const i16: FixedSizeBeet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeInt16LE(value, offset)
   },
@@ -140,7 +140,7 @@ export const i16: FixedBeet<number> = {
  *
  * @category beet/primitive
  */
-export const i32: FixedBeet<number> = {
+export const i32: FixedSizeBeet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeInt32LE(value, offset)
   },
@@ -176,28 +176,28 @@ function signedLargeBeet(byteSize: number, description: string) {
  *
  * @category beet/primitive
  */
-export const i64: FixedBeet<bignum> = signedLargeBeet(8, 'i64')
+export const i64: FixedSizeBeet<bignum> = signedLargeBeet(8, 'i64')
 /**
  * De/Serializer for 128-bit signed integers aka `i128` which serializes to a JavaScript
  * _BigNum_ via {@link https://github.com/indutny/bn.js | BN}.
  *
  * @category beet/primitive
  */
-export const i128: FixedBeet<bignum> = signedLargeBeet(16, 'i128')
+export const i128: FixedSizeBeet<bignum> = signedLargeBeet(16, 'i128')
 /**
  * De/Serializer for 256-bit signed integers aka `i256` which serializes to a JavaScript
  * _BigNum_ via {@link https://github.com/indutny/bn.js | BN}.
  *
  * @category beet/primitive
  */
-export const i256: FixedBeet<bignum> = signedLargeBeet(32, 'i256')
+export const i256: FixedSizeBeet<bignum> = signedLargeBeet(32, 'i256')
 /**
  * De/Serializer for 512-bit signed integers aka `i512` which serializes to a JavaScript
  * _BigNum_ via {@link https://github.com/indutny/bn.js | BN}.
  *
  * @category beet/primitive
  */
-export const i512: FixedBeet<bignum> = signedLargeBeet(64, 'i512')
+export const i512: FixedSizeBeet<bignum> = signedLargeBeet(64, 'i512')
 
 // -----------------
 // Boolean
@@ -207,7 +207,7 @@ export const i512: FixedBeet<bignum> = signedLargeBeet(64, 'i512')
  *
  * @category beet/primitive
  */
-export const bool: FixedBeet<boolean> = {
+export const bool: FixedSizeBeet<boolean> = {
   write: function (buf: Buffer, offset: number, value: boolean): void {
     const n = value ? 1 : 0
     u8.write(buf, offset, n)

--- a/beet/src/beets/numbers.ts
+++ b/beet/src/beets/numbers.ts
@@ -1,5 +1,5 @@
 import BN from 'bn.js'
-import { bignum, Beet, SupportedTypeDefinition } from '../types'
+import { bignum, SupportedTypeDefinition, StaticBeet } from '../types'
 import { BEET_PACKAGE } from '../types'
 
 // -----------------
@@ -11,7 +11,7 @@ import { BEET_PACKAGE } from '../types'
  *
  * @category beet/primitive
  */
-export const u8: Beet<number> = {
+export const u8: StaticBeet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeUInt8(value, offset)
   },
@@ -27,7 +27,7 @@ export const u8: Beet<number> = {
  *
  * @category beet/primitive
  */
-export const u16: Beet<number> = {
+export const u16: StaticBeet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeUInt16LE(value, offset)
   },
@@ -43,7 +43,7 @@ export const u16: Beet<number> = {
  *
  * @category beet/primitive
  */
-export const u32: Beet<number> = {
+export const u32: StaticBeet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeUInt32LE(value, offset)
   },
@@ -77,28 +77,28 @@ function unsignedLargeBeet(byteSize: number, description: string) {
  *
  * @category beet/primitive
  */
-export const u64: Beet<bignum> = unsignedLargeBeet(8, 'u64')
+export const u64: StaticBeet<bignum> = unsignedLargeBeet(8, 'u64')
 /**
  * De/Serializer for 128-bit unsigned integers aka `u128` which serializes to a JavaScript
  * _BigNum_ via {@link https://github.com/indutny/bn.js | BN}.
  *
  * @category beet/primitive
  */
-export const u128: Beet<bignum> = unsignedLargeBeet(16, 'u128')
+export const u128: StaticBeet<bignum> = unsignedLargeBeet(16, 'u128')
 /**
  * De/Serializer for 256-bit unsigned integers aka `u256` which serializes to a JavaScript
  * _BigNum_ via {@link https://github.com/indutny/bn.js | BN}.
  *
  * @category beet/primitive
  */
-export const u256: Beet<bignum> = unsignedLargeBeet(32, 'u256')
+export const u256: StaticBeet<bignum> = unsignedLargeBeet(32, 'u256')
 /**
  * De/Serializer for 512-bit unsigned integers aka `u512` which serializes to a JavaScript
  * _BigNum_ via {@link https://github.com/indutny/bn.js | BN}.
  *
  * @category beet/primitive
  */
-export const u512: Beet<bignum> = unsignedLargeBeet(64, 'u512')
+export const u512: StaticBeet<bignum> = unsignedLargeBeet(64, 'u512')
 
 // -----------------
 // Signed
@@ -108,7 +108,7 @@ export const u512: Beet<bignum> = unsignedLargeBeet(64, 'u512')
  *
  * @category beet/primitive
  */
-export const i8: Beet<number> = {
+export const i8: StaticBeet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeInt8(value, offset)
   },
@@ -124,7 +124,7 @@ export const i8: Beet<number> = {
  *
  * @category beet/primitive
  */
-export const i16: Beet<number> = {
+export const i16: StaticBeet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeInt16LE(value, offset)
   },
@@ -140,7 +140,7 @@ export const i16: Beet<number> = {
  *
  * @category beet/primitive
  */
-export const i32: Beet<number> = {
+export const i32: StaticBeet<number> = {
   write: function (buf: Buffer, offset: number, value: number) {
     buf.writeInt32LE(value, offset)
   },
@@ -176,28 +176,28 @@ function signedLargeBeet(byteSize: number, description: string) {
  *
  * @category beet/primitive
  */
-export const i64: Beet<bignum> = signedLargeBeet(8, 'i64')
+export const i64: StaticBeet<bignum> = signedLargeBeet(8, 'i64')
 /**
  * De/Serializer for 128-bit signed integers aka `i128` which serializes to a JavaScript
  * _BigNum_ via {@link https://github.com/indutny/bn.js | BN}.
  *
  * @category beet/primitive
  */
-export const i128: Beet<bignum> = signedLargeBeet(16, 'i128')
+export const i128: StaticBeet<bignum> = signedLargeBeet(16, 'i128')
 /**
  * De/Serializer for 256-bit signed integers aka `i256` which serializes to a JavaScript
  * _BigNum_ via {@link https://github.com/indutny/bn.js | BN}.
  *
  * @category beet/primitive
  */
-export const i256: Beet<bignum> = signedLargeBeet(32, 'i256')
+export const i256: StaticBeet<bignum> = signedLargeBeet(32, 'i256')
 /**
  * De/Serializer for 512-bit signed integers aka `i512` which serializes to a JavaScript
  * _BigNum_ via {@link https://github.com/indutny/bn.js | BN}.
  *
  * @category beet/primitive
  */
-export const i512: Beet<bignum> = signedLargeBeet(64, 'i512')
+export const i512: StaticBeet<bignum> = signedLargeBeet(64, 'i512')
 
 // -----------------
 // Boolean
@@ -207,7 +207,7 @@ export const i512: Beet<bignum> = signedLargeBeet(64, 'i512')
  *
  * @category beet/primitive
  */
-export const bool: Beet<boolean> = {
+export const bool: StaticBeet<boolean> = {
   write: function (buf: Buffer, offset: number, value: boolean): void {
     const n = value ? 1 : 0
     u8.write(buf, offset, n)

--- a/beet/src/beets/numbers.ts
+++ b/beet/src/beets/numbers.ts
@@ -1,6 +1,6 @@
 import BN from 'bn.js'
-import { bignum, Beet, SupportedTypeDefinition } from './types'
-import { BEET_PACKAGE } from './types'
+import { bignum, Beet, SupportedTypeDefinition } from '../types'
+import { BEET_PACKAGE } from '../types'
 
 // -----------------
 // Unsigned

--- a/beet/src/read-write.ts
+++ b/beet/src/read-write.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert'
-import { FixedBeet, FixedBeetField } from './types'
+import { FixedSizeBeet, FixedBeetField } from './types'
 
 /**
  * Underlying writer used to serialize structs.
@@ -34,7 +34,7 @@ export class BeetWriter {
     }
   }
 
-  write<T>(beet: FixedBeet<T>, value: T) {
+  write<T>(beet: FixedSizeBeet<T>, value: T) {
     this.maybeResize(beet.byteSize)
     beet.write(this.buf, this._offset, value)
     this._offset += beet.byteSize
@@ -61,7 +61,7 @@ export class BeetReader {
     return this._offset
   }
 
-  read<T>(beet: FixedBeet<T>): T {
+  read<T>(beet: FixedSizeBeet<T>): T {
     const value = beet.read(this.buffer, this._offset)
     this._offset += beet.byteSize
     return value

--- a/beet/src/read-write.ts
+++ b/beet/src/read-write.ts
@@ -1,0 +1,77 @@
+import { strict as assert } from 'assert'
+import { Beet, BeetField } from './types'
+
+/**
+ * Underlying writer used to serialize structs.
+ *
+ * @private
+ * @category beet/struct
+ */
+export class BeetWriter {
+  private buf: Buffer
+  private _offset: number
+  constructor(byteSize: number) {
+    this.buf = Buffer.alloc(byteSize)
+    this._offset = 0
+  }
+
+  get buffer() {
+    return this.buf
+  }
+
+  get offset() {
+    return this._offset
+  }
+
+  private maybeResize(bytesNeeded: number) {
+    if (this._offset + bytesNeeded > this.buf.length) {
+      assert.fail(
+        `We shouldn't ever need to resize, but ${
+          this._offset + bytesNeeded
+        } > ${this.buf.length}`
+      )
+      // this.buf = Buffer.concat([this.buf, Buffer.alloc(this.allocateBytes)])
+    }
+  }
+
+  write<T>(beet: Beet<T>, value: T) {
+    this.maybeResize(beet.byteSize)
+    beet.write(this.buf, this._offset, value)
+    this._offset += beet.byteSize
+  }
+
+  writeStruct<T>(instance: T, fields: BeetField<T>[]) {
+    for (const [key, beet] of fields) {
+      const value = instance[key]
+      this.write(beet, value)
+    }
+  }
+}
+
+/**
+ * Underlying reader used to deserialize structs.
+ *
+ * @private
+ * @category beet/struct
+ */
+export class BeetReader {
+  constructor(private readonly buffer: Buffer, private _offset: number = 0) {}
+
+  get offset() {
+    return this._offset
+  }
+
+  read<T>(beet: Beet<T>): T {
+    const value = beet.read(this.buffer, this._offset)
+    this._offset += beet.byteSize
+    return value
+  }
+
+  readStruct<T>(fields: BeetField<T>[]) {
+    const acc: T = <T>{}
+    for (const [key, beet] of fields) {
+      acc[key] = this.read(beet)
+    }
+    return acc
+  }
+}

--- a/beet/src/read-write.ts
+++ b/beet/src/read-write.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert'
-import { StaticBeet, StaticBeetField } from './types'
+import { FixedBeet, FixedBeetField } from './types'
 
 /**
  * Underlying writer used to serialize structs.
@@ -34,13 +34,13 @@ export class BeetWriter {
     }
   }
 
-  write<T>(beet: StaticBeet<T>, value: T) {
+  write<T>(beet: FixedBeet<T>, value: T) {
     this.maybeResize(beet.byteSize)
     beet.write(this.buf, this._offset, value)
     this._offset += beet.byteSize
   }
 
-  writeStruct<T>(instance: T, fields: StaticBeetField<T>[]) {
+  writeStruct<T>(instance: T, fields: FixedBeetField<T>[]) {
     for (const [key, beet] of fields) {
       const value = instance[key]
       this.write(beet, value)
@@ -61,13 +61,13 @@ export class BeetReader {
     return this._offset
   }
 
-  read<T>(beet: StaticBeet<T>): T {
+  read<T>(beet: FixedBeet<T>): T {
     const value = beet.read(this.buffer, this._offset)
     this._offset += beet.byteSize
     return value
   }
 
-  readStruct<T>(fields: StaticBeetField<T>[]) {
+  readStruct<T>(fields: FixedBeetField<T>[]) {
     const acc: T = <T>{}
     for (const [key, beet] of fields) {
       acc[key] = this.read(beet)

--- a/beet/src/read-write.ts
+++ b/beet/src/read-write.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert'
-import { Beet, BeetField } from './types'
+import { StaticBeet, StaticBeetField } from './types'
 
 /**
  * Underlying writer used to serialize structs.
@@ -34,13 +34,13 @@ export class BeetWriter {
     }
   }
 
-  write<T>(beet: Beet<T>, value: T) {
+  write<T>(beet: StaticBeet<T>, value: T) {
     this.maybeResize(beet.byteSize)
     beet.write(this.buf, this._offset, value)
     this._offset += beet.byteSize
   }
 
-  writeStruct<T>(instance: T, fields: BeetField<T>[]) {
+  writeStruct<T>(instance: T, fields: StaticBeetField<T>[]) {
     for (const [key, beet] of fields) {
       const value = instance[key]
       this.write(beet, value)
@@ -61,13 +61,13 @@ export class BeetReader {
     return this._offset
   }
 
-  read<T>(beet: Beet<T>): T {
+  read<T>(beet: StaticBeet<T>): T {
     const value = beet.read(this.buffer, this._offset)
     this._offset += beet.byteSize
     return value
   }
 
-  readStruct<T>(fields: BeetField<T>[]) {
+  readStruct<T>(fields: StaticBeetField<T>[]) {
     const acc: T = <T>{}
     for (const [key, beet] of fields) {
       acc[key] = this.read(beet)

--- a/beet/src/struct.dynamic.ts
+++ b/beet/src/struct.dynamic.ts
@@ -1,0 +1,86 @@
+import { BeetStruct } from './struct'
+import { isFixedRecursively, toFixed } from './beet.dynamic'
+import { BeetField, FixedBeetField } from './types'
+import { bytes, dynamicBytes, logDebug } from './utils'
+import { strict as assert } from 'assert'
+
+const LOG_LENGTHS = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+
+export class DynamicBeetStruct<Class, Args = Partial<Class>> {
+  /**
+   * Creates an instance of the DynamicBeetStruct.
+   *
+   * @param fields de/serializers for each field of the {@link Class}
+   * @param construct the function that creates an instance of {@link Class}
+   * from the args
+   * @param description identifies this struct for diagnostics/debugging
+   * purposes
+   */
+  constructor(
+    private readonly fields: BeetField<Args, any>[],
+    private readonly construct: (args: Args) => Class,
+    readonly description = DynamicBeetStruct.description
+  ) {
+    if (logDebug.enabled) {
+      let byteSize = 0
+      const flds = fields
+        .map(([key, val]: BeetField<Args, any>) => {
+          if (isFixedRecursively(val)) {
+            byteSize += val.byteSize
+            return `${key}: ${val.description} ${bytes(val)}`
+          }
+          val = toFixed(val, LOG_LENGTHS)
+          byteSize += val.byteSize
+          return `${key}: ${val.description} ${dynamicBytes(val)}`
+        })
+        .join('\n  ')
+      logDebug(
+        `struct ${description} {\n  ${flds}\n} ${bytes({ byteSize })} (minimum)`
+      )
+    }
+  }
+
+  toFixed(
+    lengthsMap: Map<keyof Args, number[]>
+  ): BeetStruct<Class, Args> | null {
+    const fixedFields: FixedBeetField<Args>[] = this.fields.map(
+      ([key, val]) => {
+        const lengths = lengthsMap.get(key)
+        if (lengths != null) {
+          const fixedVal = toFixed(val, lengths)
+          return [key, fixedVal]
+        }
+        if (isFixedRecursively(val)) {
+          return [key, val]
+        }
+        assert.fail(
+          `Field: ${key}: ${val.description} is not fixed but is missing a lengths entry in the map`
+        )
+      }
+    )
+    return new BeetStruct(
+      fixedFields,
+      this.construct,
+      `Fixed${this.description}`
+    )
+  }
+
+  static description = 'DynamicBeetStruct'
+}
+
+/**
+ * Convenience wrapper around {@link DynamicBeetStruct} which is used for plain JavasScript
+ * objects, like are used for option args passed to functions.
+ *
+ * @category beet/struct
+ */
+export class DynamicBeetArgsStruct<Args> extends DynamicBeetStruct<Args, Args> {
+  constructor(
+    fields: BeetField<Args, any>[],
+    description: string = DynamicBeetArgsStruct.description
+  ) {
+    super(fields, (args) => args, description)
+  }
+
+  static description = 'DynamicBeetArgsStruct'
+}

--- a/beet/src/struct.dynamic.ts
+++ b/beet/src/struct.dynamic.ts
@@ -39,11 +39,11 @@ export class DynamicSizeBeetStruct<Class, Args = Partial<Class>>
         .map(([key, val]: BeetField<Args, any>) => {
           if (isFixedRecursively(val)) {
             byteSize += val.byteSize
-            return `${key}: ${val.description} ${beetBytes(val)}`
+            return `${key}: ${val.description} ${beetBytes(val, true)}`
           }
           val = toFixed(val, LOG_LENGTHS.slice(), LMAPS)
           byteSize += val.byteSize
-          return `${key}: ${val.description} ${beetBytes(val)}`
+          return `${key}: ${val.description} ${beetBytes(val, true)}`
         })
         .join('\n  ')
       logDebug(

--- a/beet/src/struct.dynamic.ts
+++ b/beet/src/struct.dynamic.ts
@@ -1,12 +1,24 @@
 import { BeetStruct } from './struct'
 import { isFixedRecursively, toFixed } from './beet.dynamic'
-import { BeetField, FixedBeetField } from './types'
-import { bytes, dynamicBytes, logDebug } from './utils'
+import {
+  BeetField,
+  DynamicSizeBeet,
+  FixedBeetField,
+  FixedSizeBeet,
+} from './types'
+import { beetBytes, bytes, logDebug } from './utils'
 import { strict as assert } from 'assert'
 
+// The below are used to provide element count of `1` wherever one is required in order
+// to allow logging a dynamically sized struct before we know those counts
 const LOG_LENGTHS = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+const LOG_ID = '___LOGGING___'
+const LMAP = new Map().set(LOG_ID, LOG_LENGTHS.slice())
+const LMAPS = [LMAP, LMAP, LMAP, LMAP, LMAP, LMAP, LMAP, LMAP, LMAP, LMAP, LMAP]
 
-export class DynamicSizeBeetStruct<Class, Args = Partial<Class>> {
+export class DynamicSizeBeetStruct<Class, Args = Partial<Class>>
+  implements DynamicSizeBeet<Class, Args>
+{
   /**
    * Creates an instance of the DynamicBeetStruct.
    *
@@ -27,26 +39,32 @@ export class DynamicSizeBeetStruct<Class, Args = Partial<Class>> {
         .map(([key, val]: BeetField<Args, any>) => {
           if (isFixedRecursively(val)) {
             byteSize += val.byteSize
-            return `${key}: ${val.description} ${bytes(val)}`
+            return `${key}: ${val.description} ${beetBytes(val)}`
           }
-          val = toFixed(val, LOG_LENGTHS)
+          val = toFixed(val, LOG_LENGTHS.slice(), LMAPS)
           byteSize += val.byteSize
-          return `${key}: ${val.description} ${dynamicBytes(val)}`
+          return `${key}: ${val.description} ${beetBytes(val)}`
         })
         .join('\n  ')
       logDebug(
-        `struct ${description} {\n  ${flds}\n} ${bytes({ byteSize })} (minimum)`
+        `struct ${description} {\n  ${flds}\n} ${bytes(byteSize)} (minimum)`
       )
     }
   }
 
   // TODO(thlorenz): fix types so we don't need this
-  toFixed(_len: number): BeetStruct<Class, Args> {
-    return null as unknown as BeetStruct<Class, Args>
+  // @ts-ignore
+  toFixed: (len: number) => FixedSizeBeet<Class, Args>
+
+  toFixedStruct(
+    beetLengths: number[],
+    structMaps: Map<string, number[]>[] = []
+  ): BeetStruct<Class, Args> {
+    return toFixed(this, beetLengths, structMaps) as BeetStruct<Class, Args>
   }
 
   toFixedFromMap(
-    lengthsMap: Map<keyof Args, number[]>
+    lengthsMap: Map<keyof Args | typeof LOG_ID, number[]>
   ): BeetStruct<Class, Args> {
     const fixedFields: FixedBeetField<Args>[] = this.fields.map(
       ([key, val]) => {
@@ -57,6 +75,12 @@ export class DynamicSizeBeetStruct<Class, Args = Partial<Class>> {
         }
         if (isFixedRecursively(val)) {
           return [key, val]
+        }
+        // Only present when logging (see constructor)
+        const logLengths = lengthsMap.get(LOG_ID)
+        if (logLengths != null) {
+          const fixedVal = toFixed(val, logLengths.slice(0))
+          return [key, fixedVal]
         }
         assert.fail(
           `Field: ${key}: ${val.description} is not fixed but is missing a lengths entry in the map`

--- a/beet/src/struct.dynamic.ts
+++ b/beet/src/struct.dynamic.ts
@@ -6,7 +6,7 @@ import { strict as assert } from 'assert'
 
 const LOG_LENGTHS = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
 
-export class DynamicBeetStruct<Class, Args = Partial<Class>> {
+export class DynamicSizeBeetStruct<Class, Args = Partial<Class>> {
   /**
    * Creates an instance of the DynamicBeetStruct.
    *
@@ -19,7 +19,7 @@ export class DynamicBeetStruct<Class, Args = Partial<Class>> {
   constructor(
     private readonly fields: BeetField<Args, any>[],
     private readonly construct: (args: Args) => Class,
-    readonly description = DynamicBeetStruct.description
+    readonly description = DynamicSizeBeetStruct.description
   ) {
     if (logDebug.enabled) {
       let byteSize = 0
@@ -40,9 +40,14 @@ export class DynamicBeetStruct<Class, Args = Partial<Class>> {
     }
   }
 
-  toFixed(
+  // TODO(thlorenz): fix types so we don't need this
+  toFixed(_len: number): BeetStruct<Class, Args> {
+    return null as unknown as BeetStruct<Class, Args>
+  }
+
+  toFixedFromMap(
     lengthsMap: Map<keyof Args, number[]>
-  ): BeetStruct<Class, Args> | null {
+  ): BeetStruct<Class, Args> {
     const fixedFields: FixedBeetField<Args>[] = this.fields.map(
       ([key, val]) => {
         const lengths = lengthsMap.get(key)
@@ -69,12 +74,15 @@ export class DynamicBeetStruct<Class, Args = Partial<Class>> {
 }
 
 /**
- * Convenience wrapper around {@link DynamicBeetStruct} which is used for plain JavasScript
+ * Convenience wrapper around {@link DynamicSizeBeetStruct} which is used for plain JavasScript
  * objects, like are used for option args passed to functions.
  *
  * @category beet/struct
  */
-export class DynamicBeetArgsStruct<Args> extends DynamicBeetStruct<Args, Args> {
+export class DynamicBeetArgsStruct<Args> extends DynamicSizeBeetStruct<
+  Args,
+  Args
+> {
   constructor(
     fields: BeetField<Args, any>[],
     description: string = DynamicBeetArgsStruct.description

--- a/beet/src/struct.ts
+++ b/beet/src/struct.ts
@@ -1,5 +1,5 @@
 import { BeetReader, BeetWriter } from './read-write'
-import { StaticBeet, StaticBeetField } from './types'
+import { FixedBeet, FixedBeetField } from './types'
 import { bytes, logDebug, logTrace } from './utils'
 
 /**
@@ -13,7 +13,7 @@ import { bytes, logDebug, logTrace } from './utils'
  * @category beet/struct
  */
 export class BeetStruct<Class, Args = Partial<Class>>
-  implements StaticBeet<Class>
+  implements FixedBeet<Class>
 {
   readonly byteSize: number
   /**
@@ -26,7 +26,7 @@ export class BeetStruct<Class, Args = Partial<Class>>
    * purposes
    */
   constructor(
-    private readonly fields: StaticBeetField<Args>[],
+    private readonly fields: FixedBeetField<Args>[],
     private readonly construct: (args: Args) => Class,
     readonly description = BeetStruct.description
   ) {
@@ -34,7 +34,7 @@ export class BeetStruct<Class, Args = Partial<Class>>
     if (logDebug.enabled) {
       const flds = fields
         .map(
-          ([key, val]: StaticBeetField<Args>) =>
+          ([key, val]: FixedBeetField<Args>) =>
             `${key}: ${val.description} ${bytes(val)}`
         )
         .join('\n  ')
@@ -117,7 +117,7 @@ export class BeetStruct<Class, Args = Partial<Class>>
  */
 export class BeetArgsStruct<Args> extends BeetStruct<Args, Args> {
   constructor(
-    fields: StaticBeetField<Args>[],
+    fields: FixedBeetField<Args>[],
     description: string = BeetArgsStruct.description
   ) {
     super(fields, (args) => args, description)

--- a/beet/src/struct.ts
+++ b/beet/src/struct.ts
@@ -1,5 +1,5 @@
 import { BeetReader, BeetWriter } from './read-write'
-import { FixedBeet, FixedBeetField } from './types'
+import { FixedSizeBeet, FixedBeetField } from './types'
 import { bytes, logDebug, logTrace } from './utils'
 
 /**
@@ -13,7 +13,7 @@ import { bytes, logDebug, logTrace } from './utils'
  * @category beet/struct
  */
 export class BeetStruct<Class, Args = Partial<Class>>
-  implements FixedBeet<Class>
+  implements FixedSizeBeet<Class>
 {
   readonly byteSize: number
   /**

--- a/beet/src/struct.ts
+++ b/beet/src/struct.ts
@@ -1,0 +1,131 @@
+import { BeetReader, BeetWriter } from './read-write'
+import { Beet, BeetField } from './types'
+import { logDebug, logTrace } from './utils'
+import colors from 'ansicolors'
+
+const { brightBlack } = colors
+function bytes(val: { byteSize: number }) {
+  return brightBlack(`${val.byteSize} B`)
+}
+
+/**
+ * Configures a class or any JavaScript object type for de/serialization aka
+ * read/write.
+ *
+ * @template Class the type to produce when deserializing
+ * @template Args contains all fields, is typically a subset of Class and is
+ * used to construct an instance of it
+ *
+ * @category beet/struct
+ */
+export class BeetStruct<Class, Args = Partial<Class>> implements Beet<Class> {
+  readonly byteSize: number
+  /**
+   * Creates an instance of the BeetStruct.
+   *
+   * @param fields de/serializers for each field of the {@link Class}
+   * @param construct the function that creates an instance of {@link Class}
+   * from the args
+   * @param description identifies this struct for diagnostics/debugging
+   * purposes
+   */
+  constructor(
+    private readonly fields: BeetField<Args>[],
+    private readonly construct: (args: Args) => Class,
+    readonly description = BeetStruct.description
+  ) {
+    this.byteSize = this.getByteSize()
+    if (logDebug.enabled) {
+      const flds = fields
+        .map(
+          ([key, val]: BeetField<Args>) =>
+            `${key}: ${val.description} ${bytes(val)}`
+        )
+        .join('\n  ')
+      logDebug(`struct ${description} {\n  ${flds}\n} ${bytes(this)}`)
+    }
+  }
+
+  /**
+   * Along with `write` this allows structs to be treated as {@link Beet}s and
+   * thus supports composing/nesting them the same way.
+   * @private
+   */
+  read(buf: Buffer, offset: number): Class {
+    const [value] = this.deserialize(buf, offset)
+    return value
+  }
+
+  /**
+   * Along with `read` this allows structs to be treated as {@link Beet}s and
+   * thus supports composing/nesting them the same way.
+   * @private
+   */
+  write(buf: Buffer, offset: number, value: Args): void {
+    const [innerBuf, innerOffset] = this.serialize(value)
+    innerBuf.copy(buf, offset, 0, innerOffset)
+  }
+
+  /**
+   * Deserializes an instance of the Class from the provided buffer starting to
+   * read at the provided offset.
+   *
+   * @returns `[instance of Class, offset into buffer after deserialization completed]`
+   */
+  deserialize(buffer: Buffer, offset: number = 0): [Class, number] {
+    if (logTrace.enabled) {
+      logTrace(
+        'deserializing [%s] from %d bytes buffer',
+        this.description,
+        buffer.byteLength
+      )
+      logTrace(buffer)
+      logTrace(buffer.toJSON().data)
+    }
+    const reader = new BeetReader(buffer, offset)
+    const args = reader.readStruct(this.fields)
+    return [this.construct(args), reader.offset]
+  }
+
+  /**
+   * Serializes the provided instance into a new {@link Buffer}
+   *
+   * @param instance of the struct to serialize
+   * @param byteSize allows to override the size fo the created Buffer and
+   * defaults to the size of the struct to serialize
+   */
+  serialize(instance: Args, byteSize = this.byteSize): [Buffer, number] {
+    logTrace(
+      'serializing [%s] %o to %d bytes buffer',
+      this.description,
+      instance,
+      this.byteSize
+    )
+    const writer = new BeetWriter(byteSize)
+    writer.writeStruct(instance, this.fields)
+    return [writer.buffer, writer.offset]
+  }
+
+  private getByteSize() {
+    return this.fields.reduce((acc, [_, beet]) => acc + beet.byteSize, 0)
+  }
+
+  static description = 'BeetStruct'
+}
+
+/**
+ * Convenience wrapper around {@link BeetStruct} which is used for plain JavasScript
+ * objects, like are used for option args passed to functions.
+ *
+ * @category beet/struct
+ */
+export class BeetArgsStruct<Args> extends BeetStruct<Args, Args> {
+  constructor(
+    fields: BeetField<Args>[],
+    description: string = BeetArgsStruct.description
+  ) {
+    super(fields, (args) => args, description)
+  }
+
+  static description = 'BeetArgsStruct'
+}

--- a/beet/src/struct.ts
+++ b/beet/src/struct.ts
@@ -1,12 +1,6 @@
 import { BeetReader, BeetWriter } from './read-write'
-import { Beet, BeetField } from './types'
-import { logDebug, logTrace } from './utils'
-import colors from 'ansicolors'
-
-const { brightBlack } = colors
-function bytes(val: { byteSize: number }) {
-  return brightBlack(`${val.byteSize} B`)
-}
+import { StaticBeet, StaticBeetField } from './types'
+import { bytes, logDebug, logTrace } from './utils'
 
 /**
  * Configures a class or any JavaScript object type for de/serialization aka
@@ -18,7 +12,9 @@ function bytes(val: { byteSize: number }) {
  *
  * @category beet/struct
  */
-export class BeetStruct<Class, Args = Partial<Class>> implements Beet<Class> {
+export class BeetStruct<Class, Args = Partial<Class>>
+  implements StaticBeet<Class>
+{
   readonly byteSize: number
   /**
    * Creates an instance of the BeetStruct.
@@ -30,7 +26,7 @@ export class BeetStruct<Class, Args = Partial<Class>> implements Beet<Class> {
    * purposes
    */
   constructor(
-    private readonly fields: BeetField<Args>[],
+    private readonly fields: StaticBeetField<Args>[],
     private readonly construct: (args: Args) => Class,
     readonly description = BeetStruct.description
   ) {
@@ -38,7 +34,7 @@ export class BeetStruct<Class, Args = Partial<Class>> implements Beet<Class> {
     if (logDebug.enabled) {
       const flds = fields
         .map(
-          ([key, val]: BeetField<Args>) =>
+          ([key, val]: StaticBeetField<Args>) =>
             `${key}: ${val.description} ${bytes(val)}`
         )
         .join('\n  ')
@@ -121,7 +117,7 @@ export class BeetStruct<Class, Args = Partial<Class>> implements Beet<Class> {
  */
 export class BeetArgsStruct<Args> extends BeetStruct<Args, Args> {
   constructor(
-    fields: BeetField<Args>[],
+    fields: StaticBeetField<Args>[],
     description: string = BeetArgsStruct.description
   ) {
     super(fields, (args) => args, description)

--- a/beet/src/struct.ts
+++ b/beet/src/struct.ts
@@ -1,6 +1,6 @@
 import { BeetReader, BeetWriter } from './read-write'
-import { FixedSizeBeet, FixedBeetField } from './types'
-import { bytes, logDebug, logTrace } from './utils'
+import { FixedBeetField, ScalarFixedSizeBeet } from './types'
+import { beetBytes, logDebug, logTrace } from './utils'
 
 /**
  * Configures a class or any JavaScript object type for de/serialization aka
@@ -13,7 +13,7 @@ import { bytes, logDebug, logTrace } from './utils'
  * @category beet/struct
  */
 export class BeetStruct<Class, Args = Partial<Class>>
-  implements FixedSizeBeet<Class>
+  implements ScalarFixedSizeBeet<Class>
 {
   readonly byteSize: number
   /**
@@ -35,10 +35,10 @@ export class BeetStruct<Class, Args = Partial<Class>>
       const flds = fields
         .map(
           ([key, val]: FixedBeetField<Args>) =>
-            `${key}: ${val.description} ${bytes(val)}`
+            `${key}: ${val.description} ${beetBytes(val)}`
         )
         .join('\n  ')
-      logDebug(`struct ${description} {\n  ${flds}\n} ${bytes(this)}`)
+      logDebug(`struct ${description} {\n  ${flds}\n} ${beetBytes(this)}`)
     }
   }
 

--- a/beet/src/types.ts
+++ b/beet/src/types.ts
@@ -103,7 +103,12 @@ export type DynamicSizeBeetField<T> = [keyof T, DynamicSizeBeet<T[keyof T]>]
  *
  * @category beet
  */
-export type BeetField<T> = FixedBeetField<T> | DynamicSizeBeetField<T>
+export type BeetField<T, V = Partial<T>> = [
+  keyof T,
+  FixedSizeBeet<T[keyof T], V> | DynamicSizeBeet<T[keyof T], V>
+]
+
+// FixedBeetField<T> | DynamicSizeBeetField<T>
 
 /**
  * Represents a number that can be larger than the builtin Integer type.
@@ -155,7 +160,7 @@ export type SupportedTypeDefinition = {
  * @private
  */
 export function isFixedSizeBeet<T>(x: Beet<T>): x is FixedSizeBeet<T> {
-  return typeof (x as FixedSizeBeet<T>).byteSize != null
+  return Object.keys(x).includes('byteSize')
 }
 
 export function assertFixedSizeBeet<T>(
@@ -181,22 +186,4 @@ export function isCompositeBeet<T, V = Partial<T>>(
   x: Beet<T, V> | Composite<T, V, any, any>
 ): x is Composite<T, V, any, any> {
   return (x as Composite<T, V, any, any>).inner != null
-}
-
-/**
- * @private
- */
-export function isFixedSizeBeetField<T>(f: BeetField<T>) {
-  const [, beet] = f
-  return isFixedSizeBeet(beet)
-}
-
-/**
- * @private
- */
-export function isDynamicSizeBeetField<T>(
-  f: BeetField<T> | DynamicSizeBeetField<T>
-) {
-  const [, beet] = f
-  return isDynamicSizeBeet(beet)
 }

--- a/beet/src/types.ts
+++ b/beet/src/types.ts
@@ -16,7 +16,7 @@ export const BEET_PACKAGE = '@metaplex-foundation/beet'
  *
  * @category beet
  */
-export type StaticBeet<T, V = Partial<T>> = {
+export type FixedBeet<T, V = Partial<T>> = {
   /**
    * Writes the value of type {@link T} to the provided buffer.
    *
@@ -53,13 +53,13 @@ export type StaticBeet<T, V = Partial<T>> = {
  * inside out
  */
 export type DynamicSizeBeet<T, V = Partial<T>> = {
-  makeStatic: (lens: DynamicSizeLens) => StaticBeet<T, V>
+  toFixed: (lens: DynamicSizeLens) => FixedBeet<T, V>
 }
 
-export type Beet<T, V = Partial<T>> = StaticBeet<T, V> | DynamicSizeBeet<T, V>
+export type Beet<T, V = Partial<T>> = FixedBeet<T, V> | DynamicSizeBeet<T, V>
 
-export type StaticBeetCollection<T, V = Partial<T>> = StaticBeet<T[], V[]> & {
-  element: StaticBeet<T, V>
+export type FixedBeetCollection<T, V = Partial<T>> = FixedBeet<T[], V[]> & {
+  element: FixedBeet<T, V>
 }
 
 export type DynamicSizeLens = number[] | number
@@ -71,7 +71,7 @@ export type DynamicSizeLens = number[] | number
  *
  * @category beet
  */
-export type StaticBeetField<T> = [keyof T, StaticBeet<T[keyof T]>]
+export type FixedBeetField<T> = [keyof T, FixedBeet<T[keyof T]>]
 
 /**
  * Specifies a field that is part of the type {@link T} along with its De/Serializer.
@@ -89,7 +89,7 @@ export type DynamicSizeBeetField<T> = [keyof T, DynamicSizeBeet<T[keyof T]>]
  *
  * @category beet
  */
-export type BeetField<T> = StaticBeetField<T> | DynamicSizeBeetField<T>
+export type BeetField<T> = FixedBeetField<T> | DynamicSizeBeetField<T>
 
 /**
  * Represents a number that can be larger than the builtin Integer type.
@@ -140,7 +140,7 @@ export type SupportedTypeDefinition = {
 /**
  * @private
  */
-export function isStaticBeet<T>(x: Beet<T> | DynamicSizeBeet<T>): x is Beet<T> {
+export function isFixedBeet<T>(x: Beet<T> | DynamicSizeBeet<T>): x is Beet<T> {
   return typeof x !== 'function'
 }
 
@@ -156,9 +156,9 @@ export function isDynamicSizeBeet<T>(
 /**
  * @private
  */
-export function isStaticBeetField<T>(f: BeetField<T>) {
+export function isFixedBeetField<T>(f: BeetField<T>) {
   const [, beet] = f
-  return isStaticBeet(beet)
+  return isFixedBeet(beet)
 }
 
 /**
@@ -176,8 +176,8 @@ export function isDynamicSizeBeetField<T>(
  */
 export function isBeetCollection(
   beet: Beet<any>
-): beet is StaticBeetCollection<any> {
-  return (beet as StaticBeetCollection<any>).element != null
+): beet is FixedBeetCollection<any> {
+  return (beet as FixedBeetCollection<any>).element != null
 }
 
 /**

--- a/beet/src/types.ts
+++ b/beet/src/types.ts
@@ -1,5 +1,6 @@
 import BN from 'bn.js'
 import { strict as assert } from 'assert'
+import { DynamicSizeBeetStruct } from './struct.dynamic'
 
 /**
  * Matches name in package.json
@@ -177,6 +178,15 @@ export function isDynamicSizeBeet<T, V>(
   x: Beet<T, V>
 ): x is DynamicSizeBeet<T, V> {
   return typeof (x as DynamicSizeBeet<T, V>).toFixed === 'function'
+}
+
+/**
+ * @private
+ */
+export function isDynamicSizeBeetStruct<T, V>(
+  x: Beet<T, V>
+): x is DynamicSizeBeetStruct<T, V> {
+  return typeof (x as DynamicSizeBeetStruct<T, V>).toFixedFromMap === 'function'
 }
 
 /**

--- a/beet/src/utils.ts
+++ b/beet/src/utils.ts
@@ -25,3 +25,8 @@ export function beetBytes<T, V = Partial<T>>(beet: FixedSizeBeet<T, V>) {
 export function bytes(n: number) {
   return brightBlack(`${n} B`)
 }
+
+/**
+ * Use this to provide a map for structs which need no lengths
+ */
+export const EMPTY_MAP = new Map()

--- a/beet/src/utils.ts
+++ b/beet/src/utils.ts
@@ -10,3 +10,7 @@ export const logTrace = debug('beet:trace')
 export function bytes(val: { byteSize: number }) {
   return brightBlack(`${val.byteSize} B`)
 }
+
+export function dynamicBytes(val: { byteSize: number }) {
+  return brightBlack(`${val.byteSize} B * length`)
+}

--- a/beet/src/utils.ts
+++ b/beet/src/utils.ts
@@ -1,5 +1,6 @@
 import debug from 'debug'
 import colors from 'ansicolors'
+import { FixedSizeBeet, isElementCollectionFixedSizeBeet } from './types'
 const { brightBlack } = colors
 
 export const logError = debug('beet:error')
@@ -7,10 +8,20 @@ export const logInfo = debug('beet:info')
 export const logDebug = debug('beet:debug')
 export const logTrace = debug('beet:trace')
 
-export function bytes(val: { byteSize: number }) {
-  return brightBlack(`${val.byteSize} B`)
+export function beetBytes<T, V = Partial<T>>(beet: FixedSizeBeet<T, V>) {
+  let bytes: string
+  if (isElementCollectionFixedSizeBeet(beet)) {
+    const lenBytes = beet.lenPrefixByteSize
+    bytes =
+      lenBytes > 0
+        ? `${lenBytes} + (${beet.elementByteSize} * length) B  (${beet.byteSize} B)`
+        : `(${beet.elementByteSize} * length) B (${beet.byteSize} B)`
+  } else {
+    bytes = `${beet.byteSize} B`
+  }
+  return brightBlack(bytes)
 }
 
-export function dynamicBytes(val: { byteSize: number }) {
-  return brightBlack(`${val.byteSize} B * length`)
+export function bytes(n: number) {
+  return brightBlack(`${n} B`)
 }

--- a/beet/src/utils.ts
+++ b/beet/src/utils.ts
@@ -8,14 +8,18 @@ export const logInfo = debug('beet:info')
 export const logDebug = debug('beet:debug')
 export const logTrace = debug('beet:trace')
 
-export function beetBytes<T, V = Partial<T>>(beet: FixedSizeBeet<T, V>) {
+export function beetBytes<T, V = Partial<T>>(
+  beet: FixedSizeBeet<T, V>,
+  isDynamic = false
+) {
   let bytes: string
   if (isElementCollectionFixedSizeBeet(beet)) {
+    const len = isDynamic ? 'length' : beet.len
     const lenBytes = beet.lenPrefixByteSize
     bytes =
       lenBytes > 0
-        ? `${lenBytes} + (${beet.elementByteSize} * length) B  (${beet.byteSize} B)`
-        : `(${beet.elementByteSize} * length) B (${beet.byteSize} B)`
+        ? `${lenBytes} + (${beet.elementByteSize} * ${len}) B  (${beet.byteSize} B)`
+        : `(${beet.elementByteSize} * ${len}) B (${beet.byteSize} B)`
   } else {
     bytes = `${beet.byteSize} B`
   }

--- a/beet/src/utils.ts
+++ b/beet/src/utils.ts
@@ -1,6 +1,12 @@
 import debug from 'debug'
+import colors from 'ansicolors'
+const { brightBlack } = colors
 
 export const logError = debug('beet:error')
 export const logInfo = debug('beet:info')
 export const logDebug = debug('beet:debug')
 export const logTrace = debug('beet:trace')
+
+export function bytes(val: { byteSize: number }) {
+  return brightBlack(`${val.byteSize} B`)
+}

--- a/beet/test/beet.dynamic.ts
+++ b/beet/test/beet.dynamic.ts
@@ -1,0 +1,92 @@
+import spok from 'spok'
+import test from 'tape'
+import { dynamicSizeArray, toFixed } from '../src/beet.dynamic'
+import { coption } from '../src/beets/composites'
+import {
+  bool,
+  i16,
+  i32,
+  i64,
+  u128,
+  u256,
+  u32,
+  u512,
+  u64,
+  u8,
+} from '../src/beets/numbers'
+import { Beet, bignum } from '../src/types'
+
+test('toFixed: fixed primitives are already fixed', (t) => {
+  const beets = <Beet<number | bignum>[]>[u8, u128, u256, u512, i16, i32, bool]
+  for (const beet of beets) {
+    const fixed = toFixed(beet, [])
+    t.equal(fixed, beet, beet.description)
+  }
+  t.end()
+})
+
+test('toFixed: dynamicSizeArray<u8>(2)', (t) => {
+  const beet = dynamicSizeArray(u8)
+  const fixed = toFixed(beet, [2])
+  spok(t, fixed, {
+    byteSize: 4 + 2 * 1,
+    description: 'Array<u8>(2)',
+  })
+  t.end()
+})
+
+test('toFixed: dynamicSizeArray<u32>(1)', (t) => {
+  const beet = dynamicSizeArray(u32)
+  const fixed = toFixed(beet, [1])
+  spok(t, fixed, {
+    byteSize: 4 + 4,
+    description: 'Array<u32>(1)',
+  })
+  t.end()
+})
+
+test('toFixed: dynamicSizeArray<i64>(10)', (t) => {
+  const beet = dynamicSizeArray(i64)
+  const fixed = toFixed(beet, [10])
+  spok(t, fixed, {
+    byteSize: 4 + 10 * 8,
+    description: 'Array<i64>(10)',
+  })
+  t.end()
+})
+
+test('toFixed: dynamicSizeArray<coption<u8>>(2)', (t) => {
+  const beet = dynamicSizeArray(coption(u8))
+  const fixed = toFixed(beet, [2])
+  spok(t, fixed, {
+    byteSize: 4 + (4 + 1) * 2,
+    description: 'Array<COption<u8>>(2)',
+  })
+  t.end()
+})
+
+test('toFixed: coption<dynamicSizeArray<u8>>(2)', (t) => {
+  const beet = coption(dynamicSizeArray(u8))
+  const fixed = toFixed(beet, [2])
+  spok(t, fixed, {
+    byteSize: 4 + 4 + 2 * 1,
+    description: 'COption<Array<u8>(2)>',
+  })
+  t.end()
+})
+
+test('toFixed: dynamicSizeArray<coption(dynamicSizeArray(u64))>([3, 4])', (t) => {
+  // This means I have 3 elements which each contain an option of an array with 4 u8s each
+  const beet = dynamicSizeArray(coption(dynamicSizeArray(u64)))
+  const fixed = toFixed(beet, [3, 4])
+  spok(t, fixed, {
+    byteSize:
+      4 /* [] len */ +
+      3 *
+        /* Outer[] */ (4 /* Option Disc */ +
+          4 /* [] len */ +
+          4 * /* Inner [] */ 8) /* u64 */,
+    description: 'Array<COption<Array<u64>(4)>>(3)',
+  })
+  t.end()
+})

--- a/beet/test/beet.dynamic.ts
+++ b/beet/test/beet.dynamic.ts
@@ -97,7 +97,7 @@ test('toFixed: dynamicSizeArray<coption(dynamicSizeArray(u64))>([3, 4])', (t) =>
 })
 
 test('toFixed: string([12])', (t) => {
-  const beet = dynamicSizeUtf8String()
+  const beet = dynamicSizeUtf8String
   const fixed = toFixed(beet, [12])
   spok(t, fixed, {
     byteSize: 4 + 12,
@@ -107,7 +107,7 @@ test('toFixed: string([12])', (t) => {
 })
 
 test('toFixed: coption(string)([8])', (t) => {
-  const beet = coption(dynamicSizeUtf8String())
+  const beet = coption(dynamicSizeUtf8String)
   const fixed = toFixed(beet, [8])
   spok(t, fixed, {
     byteSize: 4 + 4 + 8,
@@ -117,7 +117,7 @@ test('toFixed: coption(string)([8])', (t) => {
 })
 
 test('toFixed: array(string)([10, 8])', (t) => {
-  const beet = dynamicSizeArray(dynamicSizeUtf8String())
+  const beet = dynamicSizeArray(dynamicSizeUtf8String)
   const fixed = toFixed(beet, [10, 8])
   spok(t, fixed, {
     byteSize: 4 + 10 * (4 + 8),
@@ -127,7 +127,7 @@ test('toFixed: array(string)([10, 8])', (t) => {
 })
 
 test('toFixed: array(coption(string))([10, 8])', (t) => {
-  const beet = dynamicSizeArray(coption(dynamicSizeUtf8String()))
+  const beet = dynamicSizeArray(coption(dynamicSizeUtf8String))
   const fixed = toFixed(beet, [10, 8])
   spok(t, fixed, {
     byteSize: 4 + 10 * (4 + 4 + 8),
@@ -138,7 +138,7 @@ test('toFixed: array(coption(string))([10, 8])', (t) => {
 
 test('toFixed: array(coption(array(string)))([10, 3, 8])', (t) => {
   const beet = dynamicSizeArray(
-    coption(dynamicSizeArray(dynamicSizeUtf8String()))
+    coption(dynamicSizeArray(dynamicSizeUtf8String))
   )
   const fixed = toFixed(beet, [10, 3, 8])
   spok(t, fixed, {
@@ -147,17 +147,3 @@ test('toFixed: array(coption(array(string)))([10, 3, 8])', (t) => {
   })
   t.end()
 })
-
-/*
-test('toFixed: struct with top level vec', (t) => {
-  const struct = new BeetArgsStruct(
-    // @ts-ignore
-    [['ids', dynamicSizeArray(u32)]],
-    'VecStruct'
-  )
-
-  const fixed = toFixed(struct, [3])
-  console.log(fixed)
-  t.end()
-})
-*/

--- a/beet/test/beet.dynamic.ts
+++ b/beet/test/beet.dynamic.ts
@@ -14,6 +14,7 @@ import {
   u64,
   u8,
 } from '../src/beets/numbers'
+import { BeetArgsStruct } from '../src/struct'
 import { Beet, bignum } from '../src/types'
 
 test('toFixed: fixed primitives are already fixed', (t) => {
@@ -77,7 +78,8 @@ test('toFixed: coption<dynamicSizeArray<u8>>(2)', (t) => {
 
 test('toFixed: dynamicSizeArray<coption(dynamicSizeArray(u64))>([3, 4])', (t) => {
   // This means I have 3 elements which each contain an option of an array with 4 u8s each
-  const beet = dynamicSizeArray(coption(dynamicSizeArray(u64)))
+  const innerArray: Beet<bignum[], bignum[]> = dynamicSizeArray<bignum>(u64)
+  const beet = dynamicSizeArray(coption(innerArray))
   const fixed = toFixed(beet, [3, 4])
   spok(t, fixed, {
     byteSize:
@@ -88,5 +90,17 @@ test('toFixed: dynamicSizeArray<coption(dynamicSizeArray(u64))>([3, 4])', (t) =>
           4 * /* Inner [] */ 8) /* u64 */,
     description: 'Array<COption<Array<u64>(4)>>(3)',
   })
+  t.end()
+})
+
+test('toFixed: struct with top level vec', (t) => {
+  const struct = new BeetArgsStruct(
+    // @ts-ignore
+    [['ids', dynamicSizeArray(u32)]],
+    'VecStruct'
+  )
+
+  const fixed = toFixed(struct, [3])
+  console.log(fixed)
   t.end()
 })

--- a/beet/test/beet.dynamic.ts
+++ b/beet/test/beet.dynamic.ts
@@ -1,6 +1,10 @@
 import spok from 'spok'
 import test from 'tape'
-import { dynamicSizeArray, toFixed } from '../src/beet.dynamic'
+import {
+  dynamicSizeArray,
+  dynamicSizeUtf8String,
+  toFixed,
+} from '../src/beet.dynamic'
 import { coption } from '../src/beets/composites'
 import {
   bool,
@@ -14,7 +18,6 @@ import {
   u64,
   u8,
 } from '../src/beets/numbers'
-import { BeetArgsStruct } from '../src/struct'
 import { Beet, bignum } from '../src/types'
 
 test('toFixed: fixed primitives are already fixed', (t) => {
@@ -93,6 +96,59 @@ test('toFixed: dynamicSizeArray<coption(dynamicSizeArray(u64))>([3, 4])', (t) =>
   t.end()
 })
 
+test('toFixed: string([12])', (t) => {
+  const beet = dynamicSizeUtf8String()
+  const fixed = toFixed(beet, [12])
+  spok(t, fixed, {
+    byteSize: 4 + 12,
+    description: 'Utf8String(12)',
+  })
+  t.end()
+})
+
+test('toFixed: coption(string)([8])', (t) => {
+  const beet = coption(dynamicSizeUtf8String())
+  const fixed = toFixed(beet, [8])
+  spok(t, fixed, {
+    byteSize: 4 + 4 + 8,
+    description: 'COption<Utf8String(8)>',
+  })
+  t.end()
+})
+
+test('toFixed: array(string)([10, 8])', (t) => {
+  const beet = dynamicSizeArray(dynamicSizeUtf8String())
+  const fixed = toFixed(beet, [10, 8])
+  spok(t, fixed, {
+    byteSize: 4 + 10 * (4 + 8),
+    description: 'Array<Utf8String(8)>(10)',
+  })
+  t.end()
+})
+
+test('toFixed: array(coption(string))([10, 8])', (t) => {
+  const beet = dynamicSizeArray(coption(dynamicSizeUtf8String()))
+  const fixed = toFixed(beet, [10, 8])
+  spok(t, fixed, {
+    byteSize: 4 + 10 * (4 + 4 + 8),
+    description: 'Array<COption<Utf8String(8)>>(10)',
+  })
+  t.end()
+})
+
+test('toFixed: array(coption(array(string)))([10, 3, 8])', (t) => {
+  const beet = dynamicSizeArray(
+    coption(dynamicSizeArray(dynamicSizeUtf8String()))
+  )
+  const fixed = toFixed(beet, [10, 3, 8])
+  spok(t, fixed, {
+    byteSize: 4 + 10 * (4 + 4 + 3 * (4 + 8)),
+    description: 'Array<COption<Array<Utf8String(8)>(3)>>(10)',
+  })
+  t.end()
+})
+
+/*
 test('toFixed: struct with top level vec', (t) => {
   const struct = new BeetArgsStruct(
     // @ts-ignore
@@ -104,3 +160,4 @@ test('toFixed: struct with top level vec', (t) => {
   console.log(fixed)
   t.end()
 })
+*/

--- a/beet/test/collections.array.ts
+++ b/beet/test/collections.array.ts
@@ -1,5 +1,4 @@
 import {
-  Beet,
   bool,
   fixedSizeArray,
   fixedSizeUtf8String,
@@ -64,7 +63,7 @@ test('collections: fixed size array of bool, include size', (t) => {
     [false, true, false, true],
   ]
   const offsets = [0, 4]
-  const beet: Beet<boolean[]> = fixedSizeArray(bool, 4, true)
+  const beet: FixedSizeBeet<boolean[]> = fixedSizeArray(bool, 4, true)
 
   checkCases(offsets, cases, beet, t)
   t.end()
@@ -76,7 +75,11 @@ test('collections: fixed size array of string, include size', (t) => {
     ['aaaa', 'bbbb', '*&#@'],
   ]
   const offsets = [0, 3]
-  const beet: Beet<string[]> = fixedSizeArray(fixedSizeUtf8String(4), 3, true)
+  const beet: FixedSizeBeet<string[]> = fixedSizeArray(
+    fixedSizeUtf8String(4),
+    3,
+    true
+  )
 
   checkCases(offsets, cases, beet, t)
   t.end()
@@ -88,7 +91,10 @@ test('collections: fixed size array of string, not including size', (t) => {
     ['aaaa', 'bbbb', '*&#@'],
   ]
   const offsets = [0, 3]
-  const beet: Beet<string[]> = fixedSizeArray(fixedSizeUtf8String(4), 3)
+  const beet: FixedSizeBeet<string[]> = fixedSizeArray(
+    fixedSizeUtf8String(4),
+    3
+  )
 
   checkCases(offsets, cases, beet, t)
   t.end()

--- a/beet/test/collections.array.ts
+++ b/beet/test/collections.array.ts
@@ -3,7 +3,7 @@ import {
   bool,
   fixedSizeArray,
   fixedSizeUtf8String,
-  FixedBeet,
+  FixedSizeBeet,
   u8,
 } from '../src/beet'
 import test from 'tape'
@@ -11,7 +11,7 @@ import test from 'tape'
 function checkCases<T>(
   offsets: number[],
   cases: T[][],
-  beet: FixedBeet<T[]>,
+  beet: FixedSizeBeet<T[]>,
   t: test.Test
 ) {
   for (const offset of offsets) {

--- a/beet/test/collections.array.ts
+++ b/beet/test/collections.array.ts
@@ -3,7 +3,7 @@ import {
   bool,
   fixedSizeArray,
   fixedSizeUtf8String,
-  StaticBeet,
+  FixedBeet,
   u8,
 } from '../src/beet'
 import test from 'tape'
@@ -11,7 +11,7 @@ import test from 'tape'
 function checkCases<T>(
   offsets: number[],
   cases: T[][],
-  beet: StaticBeet<T[]>,
+  beet: FixedBeet<T[]>,
   t: test.Test
 ) {
   for (const offset of offsets) {

--- a/beet/test/collections.array.ts
+++ b/beet/test/collections.array.ts
@@ -3,6 +3,7 @@ import {
   bool,
   fixedSizeArray,
   fixedSizeUtf8String,
+  StaticBeet,
   u8,
 } from '../src/beet'
 import test from 'tape'
@@ -10,7 +11,7 @@ import test from 'tape'
 function checkCases<T>(
   offsets: number[],
   cases: T[][],
-  beet: Beet<T[]>,
+  beet: StaticBeet<T[]>,
   t: test.Test
 ) {
   for (const offset of offsets) {

--- a/beet/test/collections.buffer.ts
+++ b/beet/test/collections.buffer.ts
@@ -1,10 +1,10 @@
-import { Beet, fixedSizeBuffer, StaticBeet } from '../src/beet'
+import { Beet, fixedSizeBuffer, FixedBeet } from '../src/beet'
 import test from 'tape'
 
 function checkCases(
   offsets: number[],
   cases: Buffer[],
-  beet: StaticBeet<Buffer>,
+  beet: FixedBeet<Buffer>,
   t: test.Test
 ) {
   for (const offset of offsets) {

--- a/beet/test/collections.buffer.ts
+++ b/beet/test/collections.buffer.ts
@@ -1,10 +1,10 @@
-import { Beet, fixedSizeBuffer, FixedBeet } from '../src/beet'
+import { Beet, fixedSizeBuffer, FixedSizeBeet } from '../src/beet'
 import test from 'tape'
 
 function checkCases(
   offsets: number[],
   cases: Buffer[],
-  beet: FixedBeet<Buffer>,
+  beet: FixedSizeBeet<Buffer>,
   t: test.Test
 ) {
   for (const offset of offsets) {

--- a/beet/test/collections.buffer.ts
+++ b/beet/test/collections.buffer.ts
@@ -1,10 +1,10 @@
-import { Beet, fixedSizeBuffer } from '../src/beet'
+import { Beet, fixedSizeBuffer, StaticBeet } from '../src/beet'
 import test from 'tape'
 
 function checkCases(
   offsets: number[],
   cases: Buffer[],
-  beet: Beet<Buffer>,
+  beet: StaticBeet<Buffer>,
   t: test.Test
 ) {
   for (const offset of offsets) {

--- a/beet/test/collections.string.ts
+++ b/beet/test/collections.string.ts
@@ -1,10 +1,10 @@
-import { fixedSizeUtf8String, FixedBeet } from '../src/beet'
+import { fixedSizeUtf8String, FixedSizeBeet } from '../src/beet'
 import test from 'tape'
 
 function checkCases(
   offsets: number[],
   cases: string[],
-  beet: FixedBeet<string>,
+  beet: FixedSizeBeet<string>,
   t: test.Test
 ) {
   for (const offset of offsets) {

--- a/beet/test/collections.string.ts
+++ b/beet/test/collections.string.ts
@@ -1,10 +1,10 @@
-import { fixedSizeUtf8String, StaticBeet } from '../src/beet'
+import { fixedSizeUtf8String, FixedBeet } from '../src/beet'
 import test from 'tape'
 
 function checkCases(
   offsets: number[],
   cases: string[],
-  beet: StaticBeet<string>,
+  beet: FixedBeet<string>,
   t: test.Test
 ) {
   for (const offset of offsets) {

--- a/beet/test/collections.string.ts
+++ b/beet/test/collections.string.ts
@@ -1,10 +1,10 @@
-import { Beet, fixedSizeUtf8String } from '../src/beet'
+import { fixedSizeUtf8String, StaticBeet } from '../src/beet'
 import test from 'tape'
 
 function checkCases(
   offsets: number[],
   cases: string[],
-  beet: Beet<string>,
+  beet: StaticBeet<string>,
   t: test.Test
 ) {
   for (const offset of offsets) {

--- a/beet/test/collections.uint8array.ts
+++ b/beet/test/collections.uint8array.ts
@@ -1,10 +1,10 @@
-import { Beet, fixedSizeUint8Array, FixedBeet } from '../src/beet'
+import { Beet, fixedSizeUint8Array, FixedSizeBeet } from '../src/beet'
 import test from 'tape'
 
 function checkCases(
   offsets: number[],
   cases: Uint8Array[],
-  beet: FixedBeet<Uint8Array>,
+  beet: FixedSizeBeet<Uint8Array>,
   t: test.Test
 ) {
   for (const offset of offsets) {

--- a/beet/test/collections.uint8array.ts
+++ b/beet/test/collections.uint8array.ts
@@ -1,10 +1,10 @@
-import { Beet, fixedSizeUint8Array } from '../src/beet'
+import { Beet, fixedSizeUint8Array, StaticBeet } from '../src/beet'
 import test from 'tape'
 
 function checkCases(
   offsets: number[],
   cases: Uint8Array[],
-  beet: Beet<Uint8Array>,
+  beet: StaticBeet<Uint8Array>,
   t: test.Test
 ) {
   for (const offset of offsets) {

--- a/beet/test/collections.uint8array.ts
+++ b/beet/test/collections.uint8array.ts
@@ -1,10 +1,10 @@
-import { Beet, fixedSizeUint8Array, StaticBeet } from '../src/beet'
+import { Beet, fixedSizeUint8Array, FixedBeet } from '../src/beet'
 import test from 'tape'
 
 function checkCases(
   offsets: number[],
   cases: Uint8Array[],
-  beet: StaticBeet<Uint8Array>,
+  beet: FixedBeet<Uint8Array>,
   t: test.Test
 ) {
   for (const offset of offsets) {

--- a/beet/test/composites.coption.ts
+++ b/beet/test/composites.coption.ts
@@ -3,7 +3,7 @@ import {
   coption,
   COption,
   fixedSizeUtf8String,
-  StaticBeet,
+  FixedBeet,
   u32,
   u8,
 } from '../src/beet'
@@ -12,7 +12,7 @@ import test from 'tape'
 function checkCases<T>(
   offsets: number[],
   cases: COption<T>[],
-  beet: StaticBeet<COption<T>>,
+  beet: FixedBeet<COption<T>>,
   t: test.Test
 ) {
   for (const offset of offsets) {

--- a/beet/test/composites.coption.ts
+++ b/beet/test/composites.coption.ts
@@ -3,6 +3,7 @@ import {
   coption,
   COption,
   fixedSizeUtf8String,
+  StaticBeet,
   u32,
   u8,
 } from '../src/beet'
@@ -11,7 +12,7 @@ import test from 'tape'
 function checkCases<T>(
   offsets: number[],
   cases: COption<T>[],
-  beet: Beet<COption<T>>,
+  beet: StaticBeet<COption<T>>,
   t: test.Test
 ) {
   for (const offset of offsets) {

--- a/beet/test/composites.coption.ts
+++ b/beet/test/composites.coption.ts
@@ -3,7 +3,7 @@ import {
   coption,
   COption,
   fixedSizeUtf8String,
-  FixedBeet,
+  FixedSizeBeet,
   u32,
   u8,
 } from '../src/beet'
@@ -12,7 +12,7 @@ import test from 'tape'
 function checkCases<T>(
   offsets: number[],
   cases: COption<T>[],
-  beet: FixedBeet<COption<T>>,
+  beet: FixedSizeBeet<COption<T>>,
   t: test.Test
 ) {
   for (const offset of offsets) {

--- a/beet/test/composites.enum.ts
+++ b/beet/test/composites.enum.ts
@@ -4,7 +4,7 @@ import {
   DataEnum,
   fixedSizeArray,
   fixedSizeUtf8String,
-  FixedBeet,
+  FixedSizeBeet,
   u8,
 } from '../src/beet'
 import test from 'tape'
@@ -24,7 +24,7 @@ enum Seats {
 function checkCases<Kind, Data>(
   offsets: number[],
   cases: DataEnum<Kind, Data>[],
-  beet: FixedBeet<DataEnum<Kind, Data>>,
+  beet: FixedSizeBeet<DataEnum<Kind, Data>>,
   resolve: Record<number, string>,
   t: test.Test
 ) {
@@ -68,7 +68,7 @@ test('composites: DataEnum<Color, string>', (t) => {
   ]
 
   const offsets = [0, 4]
-  const beet: FixedBeet<DataEnum<Color, string>> = dataEnum(
+  const beet: FixedSizeBeet<DataEnum<Color, string>> = dataEnum(
     fixedSizeUtf8String(5)
   )
 

--- a/beet/test/composites.enum.ts
+++ b/beet/test/composites.enum.ts
@@ -4,6 +4,7 @@ import {
   DataEnum,
   fixedSizeArray,
   fixedSizeUtf8String,
+  StaticBeet,
   u8,
 } from '../src/beet'
 import test from 'tape'
@@ -23,7 +24,7 @@ enum Seats {
 function checkCases<Kind, Data>(
   offsets: number[],
   cases: DataEnum<Kind, Data>[],
-  beet: Beet<DataEnum<Kind, Data>>,
+  beet: StaticBeet<DataEnum<Kind, Data>>,
   resolve: Record<number, string>,
   t: test.Test
 ) {
@@ -67,7 +68,9 @@ test('composites: DataEnum<Color, string>', (t) => {
   ]
 
   const offsets = [0, 4]
-  const beet: Beet<DataEnum<Color, string>> = dataEnum(fixedSizeUtf8String(5))
+  const beet: StaticBeet<DataEnum<Color, string>> = dataEnum(
+    fixedSizeUtf8String(5)
+  )
 
   checkCases(offsets, cases, beet, Color, t)
   t.end()

--- a/beet/test/composites.enum.ts
+++ b/beet/test/composites.enum.ts
@@ -4,7 +4,7 @@ import {
   DataEnum,
   fixedSizeArray,
   fixedSizeUtf8String,
-  StaticBeet,
+  FixedBeet,
   u8,
 } from '../src/beet'
 import test from 'tape'
@@ -24,7 +24,7 @@ enum Seats {
 function checkCases<Kind, Data>(
   offsets: number[],
   cases: DataEnum<Kind, Data>[],
-  beet: StaticBeet<DataEnum<Kind, Data>>,
+  beet: FixedBeet<DataEnum<Kind, Data>>,
   resolve: Record<number, string>,
   t: test.Test
 ) {
@@ -68,7 +68,7 @@ test('composites: DataEnum<Color, string>', (t) => {
   ]
 
   const offsets = [0, 4]
-  const beet: StaticBeet<DataEnum<Color, string>> = dataEnum(
+  const beet: FixedBeet<DataEnum<Color, string>> = dataEnum(
     fixedSizeUtf8String(5)
   )
 

--- a/beet/test/numbers.ts
+++ b/beet/test/numbers.ts
@@ -2,7 +2,6 @@ import BN from 'bn.js'
 import test from 'tape'
 import {
   bignum,
-  Beet,
   i16,
   i32,
   i8,
@@ -17,6 +16,7 @@ import {
   i64,
   i128,
   i256,
+  StaticBeet,
 } from '../src/beet'
 
 function oneType(
@@ -34,7 +34,7 @@ function oneType(
 function checkCases(
   offsets: number[],
   cases: bignum[],
-  beet: Beet<bignum>,
+  beet: StaticBeet<bignum>,
   t: test.Test
 ) {
   for (const offset of offsets) {

--- a/beet/test/numbers.ts
+++ b/beet/test/numbers.ts
@@ -16,7 +16,7 @@ import {
   i64,
   i128,
   i256,
-  StaticBeet,
+  FixedBeet,
 } from '../src/beet'
 
 function oneType(
@@ -34,7 +34,7 @@ function oneType(
 function checkCases(
   offsets: number[],
   cases: bignum[],
-  beet: StaticBeet<bignum>,
+  beet: FixedBeet<bignum>,
   t: test.Test
 ) {
   for (const offset of offsets) {

--- a/beet/test/numbers.ts
+++ b/beet/test/numbers.ts
@@ -16,7 +16,7 @@ import {
   i64,
   i128,
   i256,
-  FixedBeet,
+  FixedSizeBeet,
 } from '../src/beet'
 
 function oneType(
@@ -34,7 +34,7 @@ function oneType(
 function checkCases(
   offsets: number[],
   cases: bignum[],
-  beet: FixedBeet<bignum>,
+  beet: FixedSizeBeet<bignum>,
   t: test.Test
 ) {
   for (const offset of offsets) {

--- a/beet/test/structs.composites.ts
+++ b/beet/test/structs.composites.ts
@@ -9,7 +9,6 @@ import {
   DataEnum,
   fixedSizeArray,
   i32,
-  FixedSizeCollectionBeet,
   u16,
   u8,
 } from '../src/beet'
@@ -50,7 +49,7 @@ test('struct: roundtrip COption<struct>', (t) => {
 })
 
 test('struct: roundtrip Array<struct>', (t) => {
-  const beet: FixedSizeCollectionBeet<Result> = fixedSizeArray(Result.struct, 3)
+  const beet = fixedSizeArray(Result.struct, 3)
   const offsets = [0, 8]
 
   for (const offset of offsets) {

--- a/beet/test/structs.composites.ts
+++ b/beet/test/structs.composites.ts
@@ -9,6 +9,7 @@ import {
   DataEnum,
   fixedSizeArray,
   i32,
+  StaticBeet,
   u16,
   u8,
 } from '../src/beet'
@@ -49,7 +50,9 @@ test('struct: roundtrip COption<struct>', (t) => {
 })
 
 test('struct: roundtrip Array<struct>', (t) => {
-  const beet: Beet<Array<Result>> = fixedSizeArray(Result.struct, 3)
+  // TODO(thlorenz): Resolve this type error
+  // @ts-ignore
+  const beet: StaticBeet<Array<Result>> = fixedSizeArray(Result.struct, 3)
   const offsets = [0, 8]
 
   for (const offset of offsets) {

--- a/beet/test/structs.composites.ts
+++ b/beet/test/structs.composites.ts
@@ -9,7 +9,7 @@ import {
   DataEnum,
   fixedSizeArray,
   i32,
-  FixedBeetCollection,
+  FixedSizeCollectionBeet,
   u16,
   u8,
 } from '../src/beet'
@@ -50,7 +50,7 @@ test('struct: roundtrip COption<struct>', (t) => {
 })
 
 test('struct: roundtrip Array<struct>', (t) => {
-  const beet: FixedBeetCollection<Result> = fixedSizeArray(Result.struct, 3)
+  const beet: FixedSizeCollectionBeet<Result> = fixedSizeArray(Result.struct, 3)
   const offsets = [0, 8]
 
   for (const offset of offsets) {

--- a/beet/test/structs.composites.ts
+++ b/beet/test/structs.composites.ts
@@ -9,7 +9,7 @@ import {
   DataEnum,
   fixedSizeArray,
   i32,
-  StaticBeetCollection,
+  FixedBeetCollection,
   u16,
   u8,
 } from '../src/beet'
@@ -50,7 +50,7 @@ test('struct: roundtrip COption<struct>', (t) => {
 })
 
 test('struct: roundtrip Array<struct>', (t) => {
-  const beet: StaticBeetCollection<Result> = fixedSizeArray(Result.struct, 3)
+  const beet: FixedBeetCollection<Result> = fixedSizeArray(Result.struct, 3)
   const offsets = [0, 8]
 
   for (const offset of offsets) {

--- a/beet/test/structs.composites.ts
+++ b/beet/test/structs.composites.ts
@@ -9,7 +9,7 @@ import {
   DataEnum,
   fixedSizeArray,
   i32,
-  StaticBeet,
+  StaticBeetCollection,
   u16,
   u8,
 } from '../src/beet'
@@ -50,9 +50,7 @@ test('struct: roundtrip COption<struct>', (t) => {
 })
 
 test('struct: roundtrip Array<struct>', (t) => {
-  // TODO(thlorenz): Resolve this type error
-  // @ts-ignore
-  const beet: StaticBeet<Array<Result>> = fixedSizeArray(Result.struct, 3)
+  const beet: StaticBeetCollection<Result> = fixedSizeArray(Result.struct, 3)
   const offsets = [0, 8]
 
   for (const offset of offsets) {

--- a/beet/test/structs.dynamic.ts
+++ b/beet/test/structs.dynamic.ts
@@ -1,0 +1,145 @@
+import spok, { Specifications } from 'spok'
+import test from 'tape'
+import { BeetStruct, coption, COption, u32, u8 } from '../src/beet'
+import { dynamicSizeArray, dynamicSizeUtf8String } from '../src/beet.dynamic'
+import { DynamicBeetArgsStruct } from '../src/struct.dynamic'
+
+test('toFixed: struct with top level vec', (t) => {
+  type Args = {
+    ids: number[]
+    count: number
+  }
+  const struct = new DynamicBeetArgsStruct<Args>(
+    [
+      ['ids', dynamicSizeArray(u32)],
+      ['count', u32],
+    ],
+    'VecStruct'
+  )
+  {
+    t.comment('+++ not providing length for ids')
+    try {
+      struct.toFixed(new Map())
+      t.fail('should throw for missing map entry')
+    } catch (err: any) {
+      t.match(err.message, /ids: .+ not fixed.+missing a lengths entry/)
+    }
+  }
+
+  {
+    t.comment('+++ providing length 2 for ids')
+    const fixed = struct.toFixed(new Map([['ids', [2]]]))
+
+    spok(t, fixed, <Specifications<BeetStruct<Args>>>{
+      fields: [
+        [
+          'ids',
+          {
+            byteSize: 12,
+            description: 'Array<u32>(2)',
+          },
+        ],
+        [
+          'count',
+          {
+            byteSize: 4,
+            description: 'u32',
+          },
+        ],
+      ],
+      description: 'FixedVecStruct',
+      byteSize: 16,
+    })
+  }
+  t.end()
+})
+test('toFixed: struct with top level string', (t) => {
+  type Args = {
+    name: string
+    age: number
+  }
+
+  const struct = new DynamicBeetArgsStruct<Args>(
+    [
+      ['name', dynamicSizeUtf8String],
+      ['age', u8],
+    ],
+    'CustomerStruct'
+  )
+
+  const fixed = struct.toFixed(new Map().set('name', [8]))
+  spok(t, fixed, <Specifications<BeetStruct<Args>>>{
+    fields: [
+      [
+        'name',
+        {
+          byteSize: 12,
+          description: 'Utf8String(8)',
+        },
+      ],
+      [
+        'age',
+        {
+          byteSize: 1,
+          description: 'u8',
+        },
+      ],
+    ],
+    byteSize: 13,
+    description: 'FixedCustomerStruct',
+  })
+  t.end()
+})
+
+test('toFixed: struct with nested vec and string', (t) => {
+  type Args = {
+    maybeIds: COption<number[]>
+    contributors: string[]
+  }
+  const struct = new DynamicBeetArgsStruct<Args>(
+    [
+      ['maybeIds', coption(dynamicSizeArray(u32))],
+      ['contributors', dynamicSizeArray(dynamicSizeUtf8String)],
+    ],
+    'NestedStruct'
+  )
+  {
+    t.comment('+++ with valid lengths map')
+    const fixed = struct.toFixed(
+      new Map().set('maybeIds', [8]).set('contributors', [2, 16])
+    )
+
+    spok(t, fixed, <Specifications<BeetStruct<Args>>>{
+      fields: [
+        [
+          'maybeIds',
+          {
+            byteSize: 4 + 4 + 8 * 4,
+            description: 'COption<Array<u32>(8)>',
+          },
+        ],
+        [
+          'contributors',
+          {
+            byteSize: 4 + 2 * (4 + 16),
+            description: 'Array<Utf8String(16)>(2)',
+          },
+        ],
+      ],
+      description: 'FixedNestedStruct',
+      byteSize: 84,
+    })
+  }
+
+  {
+    t.comment('+++ with incomplete contributor length map')
+    try {
+      struct.toFixed(new Map().set('maybeIds', [8]).set('contributors', [2]))
+      t.fail('should throw')
+    } catch (err: any) {
+      t.match(err.message, /provide enough.+lengths.+DynamicArray<Utf8String>/i)
+    }
+  }
+
+  t.end()
+})

--- a/beet/test/utils/index.ts
+++ b/beet/test/utils/index.ts
@@ -1,0 +1,5 @@
+import { inspect } from 'util'
+
+export function deepLog(obj: any) {
+  console.log(inspect(obj, { depth: 15, colors: true }))
+}

--- a/beet/test/utils/index.ts
+++ b/beet/test/utils/index.ts
@@ -1,5 +1,5 @@
 import { inspect } from 'util'
 
 export function deepLog(obj: any) {
-  console.log(inspect(obj, { depth: 15, colors: true }))
+  console.log(inspect(obj, { depth: 15, colors: true, getters: true }))
 }


### PR DESCRIPTION
This introduces dynamic types which have variable sizes.

In the case of strings and arrays the length is not known for these types.
They can be resolved to fixed types by providing that length.

Types have been adapted to allow for both types to be part of a composite beet and a struct.

Additionally a mechanism was provided to resolve all dynamic types inside an arbitrarily nested
struct and beet. This currently works by providing an array of lengths for each struct field.
These arrays are provided to nested structs via a map of arrays.

This is a non-ideal API and will be superseeded by methods that resolve those lengths as part
of the de/serialization process.
Therefore no public documentation nor examples were added for it but the
`test/structs.dynamic.ts` and `beet.dynamic.ts` tests serve as examples and help understanding
how to use it.

### Follow Up

After fixing a borsh incompatibility around Option data representation I will work on that
easier to use API which does not require the user to pass arrays/maps of lengths.
