### PR TITLE
chore: add tool to provide rust borsh serializaion data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dist/
 .idea/
 yarn.lock
 docs
+tools/bsamples/target/
+tools/bsamples/Cargo.lock

--- a/tools/bsamples/Cargo.toml
+++ b/tools/bsamples/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bsamples"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+borsh = "0.9.1"
+anyhow = "1.0.48"
+serde = { version =  "1.0.130", features = [ "derive" ] }
+serde_json = "1.0.72"

--- a/tools/bsamples/src/composites.rs
+++ b/tools/bsamples/src/composites.rs
@@ -1,0 +1,21 @@
+use anyhow::Result;
+
+use serde::{Deserialize, Serialize};
+
+use crate::samples::{produce_samples, Sample};
+
+#[derive(Serialize, Deserialize)]
+pub struct Composites {
+    vec_opt_u8s: Vec<Sample<Vec<Option<u8>>>>,
+    opt_vec_u8s: Vec<Sample<Option<Vec<u8>>>>,
+}
+
+pub fn produce_composites() -> Result<Composites> {
+    let vec_opt_u8s = produce_samples(vec![vec![], vec![None], vec![None, Some(5), Some(7)]])?;
+    let opt_vec_u8s = produce_samples(vec![Some(vec![]), None, Some(vec![5, 7])])?;
+
+    Ok(Composites {
+        vec_opt_u8s,
+        opt_vec_u8s,
+    })
+}

--- a/tools/bsamples/src/main.rs
+++ b/tools/bsamples/src/main.rs
@@ -1,0 +1,17 @@
+use anyhow::Result;
+use borsh::{BorshDeserialize, BorshSerialize};
+use simple::produce_simple;
+mod simple;
+
+fn try_from_slice_unchecked<T: BorshDeserialize>(data: &[u8]) -> Result<T> {
+    let mut data_mut = data;
+    let result = T::deserialize(&mut data_mut)?;
+    Ok(result)
+}
+
+fn main() -> Result<()> {
+    let simple = produce_simple()?;
+    let simple_json = serde_json::to_string_pretty(&simple)?;
+    print!("{}", simple_json);
+    Ok(())
+}

--- a/tools/bsamples/src/main.rs
+++ b/tools/bsamples/src/main.rs
@@ -2,10 +2,12 @@ use std::{fs::File, io::Write};
 
 use anyhow::Result;
 use borsh::BorshDeserialize;
+use composites::produce_composites;
 use options::produce_options;
 use simple::produce_simple;
 use vecs::produce_vecs;
 
+mod composites;
 mod options;
 mod samples;
 mod simple;
@@ -32,6 +34,10 @@ fn main() -> Result<()> {
     let vecs_json = serde_json::to_string_pretty(&produce_vecs()?)?;
     let mut vecs_file = File::create(format!("{}/vecs.json", data_dir))?;
     vecs_file.write_all(vecs_json.as_bytes())?;
+
+    let composites_json = serde_json::to_string_pretty(&produce_composites()?)?;
+    let mut composites_file = File::create(format!("{}/composites.json", data_dir))?;
+    composites_file.write_all(composites_json.as_bytes())?;
 
     Ok(())
 }

--- a/tools/bsamples/src/main.rs
+++ b/tools/bsamples/src/main.rs
@@ -1,6 +1,11 @@
+use std::{fs::File, io::Write};
+
 use anyhow::Result;
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::BorshDeserialize;
+use options::produce_options;
 use simple::produce_simple;
+
+mod options;
 mod samples;
 mod simple;
 
@@ -11,8 +16,16 @@ fn try_from_slice_unchecked<T: BorshDeserialize>(data: &[u8]) -> Result<T> {
 }
 
 fn main() -> Result<()> {
-    let simple = produce_simple()?;
-    let simple_json = serde_json::to_string_pretty(&simple)?;
-    print!("{}", simple_json);
+    // TODO(thlorenz): Parse from args
+    let data_dir = "../../beet/test/compat/fixtures";
+
+    let simple_json = serde_json::to_string_pretty(&produce_simple()?)?;
+    let mut simple_file = File::create(format!("{}/simple.json", data_dir))?;
+    simple_file.write_all(simple_json.as_bytes())?;
+
+    let options_json = serde_json::to_string_pretty(&produce_options()?)?;
+    let mut options_file = File::create(format!("{}/options.json", data_dir))?;
+    options_file.write_all(options_json.as_bytes())?;
+
     Ok(())
 }

--- a/tools/bsamples/src/main.rs
+++ b/tools/bsamples/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use borsh::{BorshDeserialize, BorshSerialize};
 use simple::produce_simple;
+mod samples;
 mod simple;
 
 fn try_from_slice_unchecked<T: BorshDeserialize>(data: &[u8]) -> Result<T> {

--- a/tools/bsamples/src/main.rs
+++ b/tools/bsamples/src/main.rs
@@ -4,10 +4,12 @@ use anyhow::Result;
 use borsh::BorshDeserialize;
 use options::produce_options;
 use simple::produce_simple;
+use vecs::produce_vecs;
 
 mod options;
 mod samples;
 mod simple;
+mod vecs;
 
 fn try_from_slice_unchecked<T: BorshDeserialize>(data: &[u8]) -> Result<T> {
     let mut data_mut = data;
@@ -26,6 +28,10 @@ fn main() -> Result<()> {
     let options_json = serde_json::to_string_pretty(&produce_options()?)?;
     let mut options_file = File::create(format!("{}/options.json", data_dir))?;
     options_file.write_all(options_json.as_bytes())?;
+
+    let vecs_json = serde_json::to_string_pretty(&produce_vecs()?)?;
+    let mut vecs_file = File::create(format!("{}/vecs.json", data_dir))?;
+    vecs_file.write_all(vecs_json.as_bytes())?;
 
     Ok(())
 }

--- a/tools/bsamples/src/options.rs
+++ b/tools/bsamples/src/options.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+
+use serde::{Deserialize, Serialize};
+
+use crate::samples::{produce_samples, Sample};
+
+#[derive(Serialize, Deserialize)]
+pub struct Options {
+    strings: Vec<Sample<Option<String>>>,
+    u8s: Vec<Sample<Option<u8>>>,
+}
+
+pub fn produce_options() -> Result<Options> {
+    let strings = produce_samples(vec![
+        None,
+        Some(String::from("Bob")),
+        Some(String::from("Harry and Luise")),
+    ])?;
+    let u8s = produce_samples(vec![None, Some(0), Some(1), Some(255)])?;
+
+    Ok(Options { strings, u8s })
+}

--- a/tools/bsamples/src/samples.rs
+++ b/tools/bsamples/src/samples.rs
@@ -1,0 +1,30 @@
+use anyhow::Result;
+use borsh::BorshSerialize;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct Sample<T> {
+    pub value: T,
+    pub data: Vec<u8>,
+}
+
+impl<T> Sample<T> {
+    pub fn new(value: T, data: Vec<u8>) -> Sample<T> {
+        Sample { value, data }
+    }
+}
+
+pub fn produce_samples<T>(xs: Vec<T>) -> Result<Vec<Sample<T>>>
+where
+    T: BorshSerialize,
+{
+    let samples: Vec<Sample<T>> = xs
+        .into_iter()
+        .filter_map(|x| match x.try_to_vec() {
+            Ok(data) => Some(Sample::new(x, data)),
+            Err(_) => None,
+        })
+        .collect();
+    Ok(samples)
+}

--- a/tools/bsamples/src/simple.rs
+++ b/tools/bsamples/src/simple.rs
@@ -1,0 +1,39 @@
+use anyhow::Result;
+use borsh::BorshSerialize;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+struct Sample<T> {
+    value: T,
+    data: Vec<u8>,
+}
+
+fn produce_samples<T>(xs: Vec<T>) -> Result<Vec<Sample<T>>>
+where
+    T: BorshSerialize,
+{
+    let samples: Vec<Sample<T>> = xs
+        .into_iter()
+        .filter_map(|x| match x.try_to_vec() {
+            Ok(data) => Some(Sample { value: x, data }),
+            Err(_) => None,
+        })
+        .collect();
+    Ok(samples)
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Simple {
+    strings: Vec<Sample<String>>,
+}
+
+pub fn produce_simple() -> Result<Simple> {
+    let xs: Vec<String> = vec!["", "Bob", "Harry and Bob"]
+        .into_iter()
+        .map(|x| x.to_string())
+        .collect();
+    let strings = produce_samples(xs)?;
+
+    Ok(Simple { strings })
+}

--- a/tools/bsamples/src/simple.rs
+++ b/tools/bsamples/src/simple.rs
@@ -1,39 +1,33 @@
 use anyhow::Result;
-use borsh::BorshSerialize;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
-struct Sample<T> {
-    value: T,
-    data: Vec<u8>,
-}
-
-fn produce_samples<T>(xs: Vec<T>) -> Result<Vec<Sample<T>>>
-where
-    T: BorshSerialize,
-{
-    let samples: Vec<Sample<T>> = xs
-        .into_iter()
-        .filter_map(|x| match x.try_to_vec() {
-            Ok(data) => Some(Sample { value: x, data }),
-            Err(_) => None,
-        })
-        .collect();
-    Ok(samples)
-}
+use crate::samples::{produce_samples, Sample};
 
 #[derive(Serialize, Deserialize)]
 pub struct Simple {
     strings: Vec<Sample<String>>,
+    u8s: Vec<Sample<u8>>,
+    u128s: Vec<Sample<u128>>,
+    optu8s: Vec<Sample<Option<u8>>>,
 }
 
 pub fn produce_simple() -> Result<Simple> {
-    let xs: Vec<String> = vec!["", "Bob", "Harry and Bob"]
+    let strings: Vec<String> = vec!["", "Bob", "Harry and Bob"]
         .into_iter()
         .map(|x| x.to_string())
         .collect();
-    let strings = produce_samples(xs)?;
 
-    Ok(Simple { strings })
+    let strings = produce_samples(strings)?;
+    let u8s = produce_samples(vec![0, 1, 255])?;
+    let u128s = produce_samples(vec![0, 255, u128::MAX])?;
+
+    let optu8s = produce_samples(vec![None, Some(0), Some(1), Some(255)])?;
+
+    Ok(Simple {
+        strings,
+        u8s,
+        u128s,
+        optu8s,
+    })
 }

--- a/tools/bsamples/src/simple.rs
+++ b/tools/bsamples/src/simple.rs
@@ -9,7 +9,6 @@ pub struct Simple {
     strings: Vec<Sample<String>>,
     u8s: Vec<Sample<u8>>,
     u128s: Vec<Sample<u128>>,
-    optu8s: Vec<Sample<Option<u8>>>,
 }
 
 pub fn produce_simple() -> Result<Simple> {
@@ -22,12 +21,9 @@ pub fn produce_simple() -> Result<Simple> {
     let u8s = produce_samples(vec![0, 1, 255])?;
     let u128s = produce_samples(vec![0, 255, u128::MAX])?;
 
-    let optu8s = produce_samples(vec![None, Some(0), Some(1), Some(255)])?;
-
     Ok(Simple {
         strings,
         u8s,
         u128s,
-        optu8s,
     })
 }

--- a/tools/bsamples/src/vecs.rs
+++ b/tools/bsamples/src/vecs.rs
@@ -1,0 +1,23 @@
+use anyhow::Result;
+
+use serde::{Deserialize, Serialize};
+
+use crate::samples::{produce_samples, Sample};
+
+#[derive(Serialize, Deserialize)]
+pub struct Options {
+    strings: Vec<Sample<Vec<String>>>,
+    u8s: Vec<Sample<Vec<u8>>>,
+}
+
+pub fn produce_vecs() -> Result<Options> {
+    let strings = produce_samples(vec![
+        vec![],
+        vec![String::from("")],
+        vec![String::from("Bob")],
+        vec![String::from("Bob"), String::from("Harry and Luise")],
+    ])?;
+    let u8s = produce_samples(vec![vec![], vec![0], vec![0, 1, 255]])?;
+
+    Ok(Options { strings, u8s })
+}


### PR DESCRIPTION
In order to verify that beet is compatible with borsh (on the Rust side) I created a tool that
generates JSON data which contains both the original value and the serialized data of that
value for various data types.

This is then imported into compatibility tests.

I chose to generate this in Rust since this is what beet needs to be compatible with vs. using
a client side borsh library to check against as that might itself not be fully compatible.

### Follow Up

Will use this tool to write compat tests and make it generate sample data for more value types
as needed.
