### PR TITLE
Enums In Instructions Fixed

### DIFF
--- a/beet/src/beets/enums.ts
+++ b/beet/src/beets/enums.ts
@@ -26,7 +26,7 @@ export function fixedScalarEnum<T>(
     write(buf: Buffer, offset: number, value: T) {
       const fullEnumObject = Object.values(enumType)
       let idx = fullEnumObject.indexOf(value)
-      if (typeof value == 'number') {
+      if (typeof value === 'number') {
         idx -= fullEnumObject.length / 2
       }
       if (idx < 0) {

--- a/beet/src/beets/enums.ts
+++ b/beet/src/beets/enums.ts
@@ -25,9 +25,9 @@ export function fixedScalarEnum<T>(
   return {
     write(buf: Buffer, offset: number, value: T) {
       const fullEnumObject = Object.values(enumType)
-      let idx = fullEnumObject.indexOf(value);
-      if(typeof value == "number") {
-          idx -= fullEnumObject.length/2;
+      let idx = fullEnumObject.indexOf(value)
+      if (typeof value == 'number') {
+        idx -= fullEnumObject.length / 2
       }
       if (idx < 0) {
         assert.fail(

--- a/beet/src/beets/enums.ts
+++ b/beet/src/beets/enums.ts
@@ -25,9 +25,9 @@ export function fixedScalarEnum<T>(
   return {
     write(buf: Buffer, offset: number, value: T) {
       const fullEnumObject = Object.values(enumType)
-      let idx = vals.indexOf(value);
+      let idx = fullEnumObject.indexOf(value);
       if(typeof value == "number") {
-          idx -= vals.length/2;
+          idx -= fullEnumObject.length/2;
       }
       if (idx < 0) {
         assert.fail(

--- a/beet/src/beets/enums.ts
+++ b/beet/src/beets/enums.ts
@@ -24,7 +24,11 @@ export function fixedScalarEnum<T>(
 ): FixedSizeBeet<Enum<T>, Enum<T>> {
   return {
     write(buf: Buffer, offset: number, value: T) {
-      const idx = Object.values(enumType).indexOf(value)
+      const fullEnumObject = Object.values(enumType)
+      let idx = vals.indexOf(value);
+      if(typeof value == "number") {
+          idx -= vals.length/2;
+      }
       if (idx < 0) {
         assert.fail(
           `${value} should be a variant of the provided enum type, i.e. [ ${Object.values(


### PR DESCRIPTION
Because of how Enums are turned into objects at runtime when using an enum in instruction, we get the wrong index when serializing and enum where the value is a number.