### PR TITLE
Remove circular dependencies

### DIFF
--- a/beet/src/beets/collections.ts
+++ b/beet/src/beets/collections.ts
@@ -10,7 +10,7 @@ import { strict as assert } from 'assert'
 import { u32 } from './numbers'
 import { BEET_PACKAGE } from '../types'
 import { logTrace } from '../utils'
-import { fixBeetFromData, fixBeetFromValue } from '../beet'
+import { fixBeetFromData, fixBeetFromValue } from '../beet.fixable'
 
 /**
  * De/Serializes an array with a specific number of elements of type {@link T}

--- a/beet/src/beets/composites.ts
+++ b/beet/src/beets/composites.ts
@@ -9,7 +9,7 @@ import {
 } from '../types'
 import { BEET_PACKAGE } from '../types'
 import { logTrace } from '../utils'
-import { fixBeetFromData, fixBeetFromValue } from '../beet'
+import { fixBeetFromData, fixBeetFromValue } from '../beet.fixable'
 
 /**
  * Represents the Rust Option type {@link T}.

--- a/beet/src/struct.fixable.ts
+++ b/beet/src/struct.fixable.ts
@@ -1,4 +1,4 @@
-import { fixBeetFromData, fixBeetFromValue } from './beet'
+import { fixBeetFromData, fixBeetFromValue } from './beet.fixable'
 import { BeetStruct } from './struct'
 import { BeetField, FixableBeet, isFixedSizeBeet } from './types'
 import { strict as assert } from 'assert'


### PR DESCRIPTION
When compiling a library or app that uses Beet, it may throw circular dependency warnings that could be easily avoided. This PR fixes this.

<img width="1229" alt="CleanShot 2022-03-07 at 10 31 25@2x" src="https://user-images.githubusercontent.com/3642397/157018139-bd603f5c-b213-4792-a07f-50a7b82656e2.png">

P.S.: The `16 more` from the screenshot refer to real problematic circular dependencies generated by Solita which fail in the browser. This is a separate issue so I'll create a new issue on Solita directly and see how we can fix this.
