### PR TITLE
feat: handling uint8Arrays of varying size, aliased to bytes

### DIFF
--- a/beet/src/beet.ts
+++ b/beet/src/beet.ts
@@ -16,7 +16,13 @@ import {
 } from './beets/numbers'
 import { StringExports, stringTypeMap, StringTypeMapKey } from './beets/string'
 import { EnumsExports, enumsTypeMap, EnumsTypeMapKey } from './beets/enums'
+import {
+  AliasesExports,
+  aliasesTypeMap,
+  AliasesTypeMapKey,
+} from './beets/aliases'
 
+export * from './beets/aliases'
 export * from './beets/collections'
 export * from './beets/string'
 export * from './beets/composites'
@@ -37,6 +43,7 @@ export type BeetTypeMapKey =
   | CompositesTypeMapKey
   | EnumsTypeMapKey
   | NumbersTypeMapKey
+  | AliasesTypeMapKey
 
 /**
  * @category TypeDefinition
@@ -47,6 +54,7 @@ export type BeetExports =
   | CompositesExports
   | EnumsExports
   | NumbersExports
+  | AliasesExports
 
 /**
  * Maps all {@link Beet} de/serializers to metadata which describes in which
@@ -66,4 +74,5 @@ export const supportedTypeMap: Record<
   ...compositesTypeMap,
   ...enumsTypeMap,
   ...numbersTypeMap,
+  ...aliasesTypeMap,
 }

--- a/beet/src/beets/aliases.ts
+++ b/beet/src/beets/aliases.ts
@@ -1,0 +1,30 @@
+import { FixableBeet, SupportedTypeDefinition } from '../types'
+import { collectionsTypeMap, uint8Array } from './collections'
+
+/**
+ * Alias for {@link uint8Array}.
+ * @category TypeDefinition
+ */
+export const bytes: FixableBeet<Uint8Array, Uint8Array> = uint8Array
+
+/**
+ * @category TypeDefinition
+ */
+export type AliasesExports = keyof typeof import('./aliases')
+/**
+ * @category TypeDefinition
+ */
+export type AliasesTypeMapKey = 'Uint8Array'
+
+/**
+ * @category TypeDefinition
+ */
+export type AliasesTypeMap = Record<
+  AliasesTypeMapKey,
+  SupportedTypeDefinition & { beet: AliasesExports }
+>
+
+export const aliasesTypeMap: AliasesTypeMap = {
+  // @ts-ignore
+  bytes: collectionsTypeMap.Uint8Array,
+}

--- a/beet/test/compat/vecs.ts
+++ b/beet/test/compat/vecs.ts
@@ -1,28 +1,65 @@
 import test from 'tape'
-import { array, u8, utf8String } from '../../src/beet'
+import { array, u8, uint8Array, utf8String } from '../../src/beet'
 import { checkFixedSerialization } from '../utils'
 import fixture from './fixtures/vecs.json'
 
 test('compat vecs: u8s', (t) => {
-  const beet = array(u8)
-  for (const { value, data } of fixture.u8s) {
-    const fixedFromValue = beet.toFixedFromValue(value)
-    checkFixedSerialization(
-      t,
-      fixedFromValue,
-      value,
-      data,
-      `fixedFromValue: [ ${value.join(', ')} ]`
-    )
+  for (const { value, data } of fixture.u8s.slice(0, 3)) {
+    // -----------------
+    // Interpreting as Array[number]
+    // -----------------
 
-    const fixedFromData = beet.toFixedFromData(Buffer.from(data), 0)
-    checkFixedSerialization(
-      t,
-      fixedFromData,
-      value,
-      data,
-      `fixedFromData: [ ${value.join(', ')} ]`
-    )
+    {
+      const beet = array(u8)
+      const fixedFromValue = beet.toFixedFromValue(value)
+      checkFixedSerialization(
+        t,
+        fixedFromValue,
+        value,
+        data,
+        `fixedFromValue: [ ${value.join(', ')} ]`
+      )
+
+      const fixedFromData = beet.toFixedFromData(Buffer.from(data), 0)
+      checkFixedSerialization(
+        t,
+        fixedFromData,
+        value,
+        data,
+        `fixedFromData: [ ${value.join(', ')} ]`
+      )
+    }
+
+    // -----------------
+    // Interpreting as Uint8Array
+    // -----------------
+    {
+      const beet = uint8Array
+      const uint8Value = Uint8Array.from(value)
+      const fixedFromValue = beet.toFixedFromValue(uint8Value)
+      checkFixedSerialization(
+        t,
+        fixedFromValue,
+        uint8Value,
+        data,
+        `fixedFromValue: [ ${value.join(', ')} ]`
+      )
+
+      const fixedFromData = beet.toFixedFromData(
+        Buffer.concat([
+          Buffer.from([value.length, 0, 0, 0]),
+          Buffer.from(data),
+        ]),
+        0
+      )
+      checkFixedSerialization(
+        t,
+        fixedFromData,
+        uint8Value,
+        data,
+        `fixedFromData: [ ${value.join(', ')} ]`
+      )
+    }
   }
   t.end()
 })

--- a/beet/test/unit/collections.uint8array.ts
+++ b/beet/test/unit/collections.uint8array.ts
@@ -1,7 +1,13 @@
-import { Beet, fixedSizeUint8Array, FixedSizeBeet } from '../../src/beet'
+import {
+  Beet,
+  fixedSizeUint8Array,
+  FixedSizeBeet,
+  uint8Array,
+  FixableBeet,
+} from '../../src/beet'
 import test from 'tape'
 
-function checkCases(
+function checkFixedCases(
   offsets: number[],
   cases: Uint8Array[],
   beet: FixedSizeBeet<Uint8Array>,
@@ -27,11 +33,68 @@ function checkCases(
   }
 }
 
+function checkFixableCases(
+  offsets: number[],
+  cases: Uint8Array[],
+  fixable: FixableBeet<Uint8Array, Uint8Array>,
+  t: test.Test
+) {
+  for (const offset of offsets) {
+    for (const x of cases) {
+      const beet = fixable.toFixedFromValue(x)
+      {
+        // Larger buffer
+        const buf = Buffer.alloc(offset + beet.byteSize + offset)
+        beet.write(buf, offset, x)
+        const y = beet.read(buf, offset)
+        t.deepEqual(
+          x,
+          y,
+          `round trip ${x} == ${y}, offset ${offset} larger buffer`
+        )
+      }
+      {
+        // Exact buffer
+        const buf = Buffer.alloc(offset + beet.byteSize)
+        beet.write(buf, offset, x)
+        const y = beet.read(buf, offset)
+        t.deepEqual(
+          x,
+          y,
+          `round trip ${x} == ${y}, offset ${offset} exact buffer`
+        )
+      }
+    }
+  }
+}
+
 test('collections: fixed size Uint8Array', (t) => {
   const cases = [Uint8Array.from([1, 2, 0xff]), Uint8Array.from([0, 10, 99])]
   const offsets = [0, 3]
   const beet: Beet<Uint8Array> = fixedSizeUint8Array(3)
 
-  checkCases(offsets, cases, beet, t)
+  checkFixedCases(offsets, cases, beet, t)
+  t.end()
+})
+
+test('collections: fixable size Uint8Array', (t) => {
+  const cases = [
+    Uint8Array.from([1, 2, 0xff]),
+    Uint8Array.from([0, 10, 99, 999, 9999]),
+  ]
+  const offsets = [0, 3]
+  const beet: FixableBeet<Uint8Array, Uint8Array> = uint8Array
+  checkFixableCases(offsets, cases, beet, t)
+
+  // Ensure from data fixing (first four bytes indicate len)
+  t.equal(
+    beet.toFixedFromData(Buffer.from([3, 0, 0, 0, 1, 2, 3]), 0).byteSize,
+    4 + 3
+  )
+  t.equal(
+    beet.toFixedFromData(Buffer.from([0, 5, 0, 0, 0, 1, 2, 3, 4, 5]), 1)
+      .byteSize,
+    4 + 5
+  )
   t.end()
 })


### PR DESCRIPTION
## Summary

Introduces both `uint8Array` and an alias `bytes` to convert `Uint8Array` of varying length.

- tests for isolated conversion
- tests for compat cases interpreting as Uint8Array
- tests for bytes as part of a struct
- bytes are exposed as alias and just forward to uint8Array

Since `FixedSizeUint8Array` was previously just `Uint8Array` this is a breaking change.