### PR TITLE
feat: beet-solana adds gpa builders

### DIFF
--- a/beet-solana/README.md
+++ b/beet-solana/README.md
@@ -6,9 +6,109 @@ Solana specific extension for beet, the borsh compatible de/serializer
 
 Please find the [API docs here](https://metaplex-foundation.github.io/beet/docs/beet-solana).
 
-## Examples
+## GPA Builders
 
-### Using PublicKey Directly
+solana-beet uses `beet`s knowledge about account layouts to provide `GpaBuilder`s for
+them which allow to filter by account data size and content.
+
+1. Create a GPA Builder via `const gpaBuilder = GpaBuilder.fromStruct(programId, accountStruct)`
+2. add filters via `gpaBuilder.dataSize`, `gpaBuilder.addFilter` or `gpaBuilder.addInnerFilter`
+3. execute `gpaBuilder.run(connection)` which will return all accounts matching the specified
+filters
+
+### Examples
+
+#### Simple struct with primitives
+
+```ts
+export type ResultsArgs = Pick<Results, 'win' | 'totalWin' | 'losses'>
+export class Results {
+  constructor(
+    readonly win: number,
+    readonly totalWin: number,
+    readonly losses: number
+  ) {}
+
+  static readonly struct = new BeetStruct<Results, ResultsArgs>(
+    [
+      ['win', u8],
+      ['totalWin', u16],
+      ['losses', i32],
+    ],
+    (args: ResultsArgs) => new Results(args.win!, args.totalWin!, args.losses!),
+    'Results'
+  )
+}
+
+const gpaBuilder = GpaBuilder.fromStruct(PROGRAM_ID, Results.struct)
+const accounts = await gpaBuilder
+  .addFilter('totalWin', 8)
+  .addFilter('losses', -7)
+  .run()
+```
+
+#### Matching on Complete Nested Struct
+
+_Using `Results` struct from above_
+
+```ts
+export type TraderArgs = Pick<Trader, 'name' | 'results' | 'age'>
+export class Trader {
+  constructor(
+    readonly name: string,
+    readonly results: Results,
+    readonly age: number
+  ) {}
+
+  static readonly struct = new BeetStruct<Trader, TraderArgs>(
+    [
+      ['name', fixedSizeUtf8String(4)],
+      ['results', Results.struct],
+      ['age', u8],
+    ],
+    (args) => new Trader(args.name!, args.results!, args.age!),
+    'Trader'
+  )
+}
+
+const gpaBuilder = GpaBuilder.fromStruct<Trader>(
+  PROGRAM_ID,
+  Trader.struct
+)
+
+const results = {
+  win: 3,
+  totalWin: 4,
+  losses: -100,
+}
+
+const accounts = await gpaBuilder.addFilter('results', results).run()
+```
+
+#### Matching on Part of Nested Struct
+
+_Using `Trader` struct from above_
+
+```ts
+const gpaBuilder = GpaBuilder.fromStruct<Trader>(
+  PROGRAM_ID,
+  Trader.struct
+)
+
+const account = await gpaBuilder
+  .addInnerFilter('results.totalWin', 8)
+  .addInnerFilter('results.win', 2)
+  .run()
+```
+
+## PublicKey
+
+solana-beet provides a de/serializer for solana public keys.
+They can either be used directly or as part of a struct.
+
+### Examples
+
+#### Using PublicKey Directly
 
 ```ts
 import { publicKey } from '@metaplex-foundation/beet-solana'
@@ -19,7 +119,7 @@ beet.write(buf, 0, generatedKey)
 beet.read(buf, 0) // same as generatedKey
 ```
 
-### PublicKey as part of a Struct Configuration
+#### PublicKey as part of a Struct Configuration
 
 ```ts
 import * as web3 from '@solana/web3.js'
@@ -31,7 +131,7 @@ type InstructionArgs = {
 }
 
 const createStruct = new beet.BeetArgsStruct<InstructionArgs>(
-  [ 
+  [
     ['authority', beetSolana.publicKey]
   ],
   'InstructionArgs'

--- a/beet-solana/package.json
+++ b/beet-solana/package.json
@@ -36,7 +36,8 @@
   ],
   "dependencies": {
     "@metaplex-foundation/beet": ">=0.1.0",
-    "@solana/web3.js": "^1.44.0"
+    "@solana/web3.js": "^1.44.0",
+    "bs58": "^5.0.0"
   },
   "devDependencies": {
     "@types/node": "^14.18.0",

--- a/beet-solana/package.json
+++ b/beet-solana/package.json
@@ -37,9 +37,11 @@
   "dependencies": {
     "@metaplex-foundation/beet": ">=0.1.0",
     "@solana/web3.js": "^1.44.0",
-    "bs58": "^5.0.0"
+    "bs58": "^5.0.0",
+    "debug": "^4.3.4"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.7",
     "@types/node": "^14.18.0",
     "@types/node-fetch": "^2.6.1",
     "@types/tape": "^4.13.2",

--- a/beet-solana/package.json
+++ b/beet-solana/package.json
@@ -45,6 +45,7 @@
     "@types/tape": "^4.13.2",
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
+    "spok": "^1.4.3",
     "tape": "^5.3.2",
     "typedoc": "^0.22.10",
     "typescript": "^4.5.2"

--- a/beet-solana/src/beet-solana.ts
+++ b/beet-solana/src/beet-solana.ts
@@ -2,6 +2,7 @@ import { SupportedTypeDefinition } from '@metaplex-foundation/beet'
 import { KeysExports, keysTypeMap, KeysTypeMapKey } from './keys'
 
 export * from './keys'
+export * from './gpa'
 
 /**
  * @category TypeDefinition

--- a/beet-solana/src/gpa/index.ts
+++ b/beet-solana/src/gpa/index.ts
@@ -51,7 +51,7 @@ export class GpaBuilder<T> {
     return this._addFilter({ dataSize: size })
   }
 
-  addFilter(key: keyof T & string, val: any) {
+  addFilter(key: keyof T & string, val: T[keyof T]) {
     const beetInfo = this.beets.get(key)
     assert(beetInfo != null, 'Filter key needs to be an existing field name')
 
@@ -83,7 +83,10 @@ export class GpaBuilder<T> {
    * @param programId the id of the program that owns the accounts we are querying
    * @param beetFields the beet fields that make up the structure of the account data
    */
-  static fromBeetFields<T>(programId: PublicKey, beetFields: BeetField<T>[]) {
+  static fromBeetFields<T>(
+    programId: PublicKey,
+    beetFields: BeetField<T, T[keyof T]>[]
+  ) {
     const map = new Map<
       keyof T & string,
       {
@@ -112,7 +115,7 @@ export class GpaBuilder<T> {
    */
   static fromStruct<T>(
     programId: PublicKey,
-    struct: { fields: BeetField<T>[] }
+    struct: { fields: BeetField<T, T[keyof T]>[] }
   ) {
     return GpaBuilder.fromBeetFields(programId, struct.fields)
   }

--- a/beet-solana/src/gpa/index.ts
+++ b/beet-solana/src/gpa/index.ts
@@ -1,0 +1,119 @@
+import {
+  BeetField,
+  FixableBeet,
+  FixedSizeBeet,
+  isFixedSizeBeet,
+} from '@metaplex-foundation/beet'
+import {
+  Connection,
+  GetProgramAccountsConfig,
+  GetProgramAccountsFilter,
+  PublicKey,
+} from '@solana/web3.js'
+import { strict as assert } from 'assert'
+import { encodeFixedBeet } from './util'
+
+type FieldBeetType<T> =
+  | FixedSizeBeet<T[keyof T]>
+  | FixableBeet<T[keyof T], T[keyof T]>
+
+export class GpaBuilder<T> {
+  readonly config: GetProgramAccountsConfig = {}
+
+  private constructor(
+    private readonly programId: PublicKey,
+    private readonly beets: Map<
+      keyof T & string,
+      {
+        beet: FieldBeetType<T>
+        offset: number
+      }
+    >,
+    private readonly accountSize: number | undefined
+  ) {}
+
+  private _addFilter(filter: GetProgramAccountsFilter) {
+    if (this.config.filters == null) {
+      this.config.filters = []
+    }
+
+    this.config.filters.push(filter)
+
+    return this
+  }
+
+  dataSize(size?: number) {
+    size = size ?? this.accountSize
+    assert(
+      size != null,
+      'for accounts of dynamic size the dataSize arg needs to be provided'
+    )
+    return this._addFilter({ dataSize: size })
+  }
+
+  addFilter(key: keyof T & string, val: any) {
+    const beetInfo = this.beets.get(key)
+    assert(beetInfo != null, 'Filter key needs to be an existing field name')
+
+    const beet = isFixedSizeBeet(beetInfo.beet)
+      ? beetInfo.beet
+      : beetInfo.beet.toFixedFromValue(val)
+
+    const bytes = encodeFixedBeet(beet, val)
+    this._addFilter({ memcmp: { offset: beetInfo.offset, bytes } })
+    return this
+  }
+
+  /**
+   * Attempts to find the accounts matching the configured filters.
+   *
+   * @param connection used to query the program accounts on the cluster
+   */
+  run(connection: Connection) {
+    return connection.getProgramAccounts(this.programId, this.config)
+  }
+
+  /**
+   * Creates a GPA builder that supports adding up to four filters for
+   * fixed size fields.
+   * Once a non-fixed field is encountered, the remaining fields following it
+   * will not be included as a filter option since it their position in the
+   * bytes array will change depending on the content of the non-fixed field.
+   *
+   * @param programId the id of the program that owns the accounts we are querying
+   * @param beetFields the beet fields that make up the structure of the account data
+   */
+  static fromBeetFields<T>(programId: PublicKey, beetFields: BeetField<T>[]) {
+    const map = new Map<
+      keyof T & string,
+      {
+        beet: FieldBeetType<T>
+        offset: number
+      }
+    >()
+
+    let offset = 0
+    let encounteredNonFixed = false
+    for (const [k, v] of beetFields) {
+      map.set(k, { beet: v as FieldBeetType<T>, offset })
+      if (!isFixedSizeBeet(v)) {
+        encounteredNonFixed = true
+        break
+      }
+      offset += v.byteSize
+    }
+    const accountSize = encounteredNonFixed ? undefined : offset
+    return new GpaBuilder<T>(programId, map, accountSize)
+  }
+
+  /**
+   * Convenience wrapper around {@link GpaBuilder.fromBeetFields} that allows
+   * providing a struct which contains the beet fields.
+   */
+  static fromStruct<T>(
+    programId: PublicKey,
+    struct: { fields: BeetField<T>[] }
+  ) {
+    return GpaBuilder.fromBeetFields(programId, struct.fields)
+  }
+}

--- a/beet-solana/src/gpa/index.ts
+++ b/beet-solana/src/gpa/index.ts
@@ -45,15 +45,6 @@ export class GpaBuilder<T> {
     return this
   }
 
-  dataSize(size?: number) {
-    size = size ?? this.accountSize
-    assert(
-      size != null,
-      'for accounts of dynamic size the dataSize arg needs to be provided'
-    )
-    return this._addFilter({ dataSize: size })
-  }
-
   private _addInnerFilter(
     key: keyof T & string,
     innerKey: string,
@@ -149,6 +140,22 @@ export class GpaBuilder<T> {
   }
 
   /**
+   * Adds a `dataSize` filter which will match on account's sizes.
+   * You have to provide that {@link size} for accounts that don't have a fixed size.
+   * For _fixed_ size accounts that size is determined for you.
+   *
+   * @param size - the account size to match for
+   */
+  dataSize(size?: number) {
+    size = size ?? this.accountSize
+    assert(
+      size != null,
+      'for accounts of dynamic size the dataSize arg needs to be provided'
+    )
+    return this._addFilter({ dataSize: size })
+  }
+
+  /**
    * Attempts to find the accounts matching the configured filters.
    *
    * @param connection used to query the program accounts on the cluster
@@ -164,8 +171,8 @@ export class GpaBuilder<T> {
    * will not be included as a filter option since it their position in the
    * bytes array will change depending on the content of the non-fixed field.
    *
-   * @param programId the id of the program that owns the accounts we are querying
-   * @param beetFields the beet fields that make up the structure of the account data
+   * @param programId - the id of the program that owns the accounts we are querying
+   * @param beetFields - the beet fields that make up the structure of the account data
    */
   static fromBeetFields<T>(
     programId: PublicKey,
@@ -196,6 +203,9 @@ export class GpaBuilder<T> {
   /**
    * Convenience wrapper around {@link GpaBuilder.fromBeetFields} that allows
    * providing a struct which contains the beet fields.
+   *
+   * @param - programId the id of the program that owns the accounts we are querying
+   * @param struct - containing the beet `fields` specifying the layout of the account
    */
   static fromStruct<T>(
     programId: PublicKey,

--- a/beet-solana/src/gpa/util.ts
+++ b/beet-solana/src/gpa/util.ts
@@ -1,0 +1,8 @@
+import { FixedSizeBeet } from '@metaplex-foundation/beet'
+import base58 from 'bs58'
+
+export function encodeFixedBeet<T>(beet: FixedSizeBeet<T>, val: T) {
+  const buf = Buffer.alloc(beet.byteSize)
+  beet.write(buf, 0, val)
+  return base58.encode(buf)
+}

--- a/beet-solana/src/utils.ts
+++ b/beet-solana/src/utils.ts
@@ -1,0 +1,6 @@
+import debug from 'debug'
+
+export const logError = debug('beet:error')
+export const logInfo = debug('beet:info')
+export const logDebug = debug('beet:debug')
+export const logTrace = debug('beet:trace')

--- a/beet-solana/test/gpa.nested.ts
+++ b/beet-solana/test/gpa.nested.ts
@@ -1,0 +1,76 @@
+import test from 'tape'
+import spok from 'spok'
+import { PROGRAM_ID, Results, Trader, withDecodedBytes } from './utils'
+import { GpaBuilder } from 'src/beet-solana'
+
+test('gpa: fixed struct nested inside fixed struct', (t) => {
+  // Expected Filters
+  const nameFilter = (name: string) => ({
+    memcmp: {
+      offset: 0,
+      bytes: Buffer.concat([
+        Buffer.from([4, 0, 0, 0]), // length
+        Buffer.from(name),
+      ]),
+    },
+  })
+  const ageFilter = (age: number) => ({
+    memcmp: { offset: 15, bytes: Buffer.from([age]) },
+  })
+
+  const resultsFilter = (results: Results) => {
+    const bytes = Results.struct.serialize(results)[0]
+    return {
+      memcmp: {
+        offset: 8,
+        bytes,
+      },
+    }
+  }
+
+  // Prep
+  let gpaBuilder: GpaBuilder<Trader> = GpaBuilder.fromStruct<Trader>(
+    PROGRAM_ID,
+    Trader.struct
+  )
+  function prepCase(comment: string) {
+    t.comment(comment)
+    gpaBuilder = GpaBuilder.fromStruct<Trader>(PROGRAM_ID, Trader.struct)
+  }
+
+  // Tests
+  prepCase(
+    `name whic is before results struct - gpaBuilder.addFilter('name', 'trad')`
+  )
+  gpaBuilder.addFilter('name', 'trad')
+  spok(t, withDecodedBytes(gpaBuilder.config), {
+    filters: [nameFilter('trad')],
+  })
+
+  prepCase(
+    `age which is after results struct - gpaBuilder.addFilter('age', 99)`
+  )
+  gpaBuilder.addFilter('age', 99)
+  spok(t, withDecodedBytes(gpaBuilder.config), {
+    filters: [ageFilter(99)],
+  })
+
+  prepCase(`gpaBuilder.addFilter('name', 'trad').addFilter('age', 99)`)
+  gpaBuilder.addFilter('name', 'trad').addFilter('age', 99)
+  spok(t, withDecodedBytes(gpaBuilder.config), {
+    filters: [nameFilter('trad'), ageFilter(99)],
+  })
+
+  prepCase(`gpaBuilder.addFilter('results', { win, totalWin, losses })`)
+  const results = {
+    win: 3,
+    totalWin: 4,
+    losses: -100,
+  }
+  gpaBuilder.addFilter('results', results)
+  spok(t, withDecodedBytes(gpaBuilder.config), {
+    filters: [resultsFilter(results)],
+  })
+
+  t.end()
+})

--- a/beet-solana/test/gpa.ts
+++ b/beet-solana/test/gpa.ts
@@ -29,10 +29,6 @@ test('gpa: fixed struct with one u8', (t) => {
 })
 
 test('gpa: fixed struct with two u8s', (t) => {
-  type Args = {
-    n: number
-    nn: number
-  }
   const struct = new BeetStruct(
     [
       ['n', u8],
@@ -41,7 +37,7 @@ test('gpa: fixed struct with two u8s', (t) => {
     (args) => args
   )
 
-  let gpaBuilder: GpaBuilder<Args> = GpaBuilder.fromStruct(PROGRAM_ID, struct)
+  let gpaBuilder = GpaBuilder.fromStruct(PROGRAM_ID, struct)
   function prepCase(comment: string) {
     t.comment(comment)
     gpaBuilder = GpaBuilder.fromStruct(PROGRAM_ID, struct)
@@ -91,10 +87,7 @@ test('gpa: fixed struct with two u8s', (t) => {
 })
 
 test('gpa: fixed struct with three ints', (t) => {
-  let gpaBuilder: GpaBuilder<Results> = GpaBuilder.fromStruct<Results>(
-    PROGRAM_ID,
-    Results.struct
-  )
+  let gpaBuilder = GpaBuilder.fromStruct<Results>(PROGRAM_ID, Results.struct)
   function prepCase(comment: string) {
     t.comment(comment)
     gpaBuilder = GpaBuilder.fromStruct<Results>(PROGRAM_ID, Results.struct)

--- a/beet-solana/test/gpa.ts
+++ b/beet-solana/test/gpa.ts
@@ -1,0 +1,129 @@
+import test from 'tape'
+import spok from 'spok'
+import { BeetStruct } from '@metaplex-foundation/beet'
+import { u8 } from '@metaplex-foundation/beet'
+import {
+  GetProgramAccountsConfig,
+  GetProgramAccountsFilter,
+  MemcmpFilter,
+  PublicKey,
+} from '@solana/web3.js'
+import { GpaBuilder } from '../src/gpa'
+import base58 from 'bs58'
+
+import * as util from 'util'
+
+const PROGRAM_ID = new PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ')
+
+// @ts-ignore
+function inspect(obj: any, colors = true) {
+  console.log(util.inspect(obj, { colors, depth: 5 }))
+}
+
+function isMemcmpFilter(x: GetProgramAccountsFilter): x is MemcmpFilter {
+  return (x as MemcmpFilter).memcmp != null
+}
+
+function withDecodedBytes(config: GetProgramAccountsConfig) {
+  const filters = []
+  if (config.filters != null) {
+    for (const x of config.filters) {
+      if (isMemcmpFilter(x)) {
+        filters.push({
+          memcmp: {
+            offset: x.memcmp.offset,
+            bytes: base58.decode(x.memcmp.bytes),
+          },
+        })
+      } else {
+        filters.push({ dataSize: x.dataSize })
+      }
+    }
+  }
+  return { ...config, filters }
+}
+
+test('gpa: fixed struct with one u8', (t) => {
+  type Args = {
+    n: number
+  }
+  const struct = new BeetStruct([['n', u8]], (args) => args)
+
+  let gpaBuilder: GpaBuilder<Args> = GpaBuilder.fromStruct(PROGRAM_ID, struct)
+  function prepCase(comment: string) {
+    t.comment(comment)
+    gpaBuilder = GpaBuilder.fromStruct(PROGRAM_ID, struct)
+  }
+
+  t.deepEqual(gpaBuilder.config, {}, 'initially config is empty')
+
+  prepCase(`gpaBuilder.addFilter('n', 2)`)
+  gpaBuilder.addFilter('n', 2)
+  spok(t, withDecodedBytes(gpaBuilder.config), {
+    filters: [{ memcmp: { offset: 0, bytes: Buffer.from([2]) } }],
+  })
+
+  t.end()
+})
+
+test('gpa: fixed struct with two u8s', (t) => {
+  type Args = {
+    n: number
+    nn: number
+  }
+  const struct = new BeetStruct(
+    [
+      ['n', u8],
+      ['nn', u8],
+    ],
+    (args) => args
+  )
+
+  let gpaBuilder: GpaBuilder<Args> = GpaBuilder.fromStruct(PROGRAM_ID, struct)
+  function prepCase(comment: string) {
+    t.comment(comment)
+    gpaBuilder = GpaBuilder.fromStruct(PROGRAM_ID, struct)
+  }
+
+  t.deepEqual(gpaBuilder.config, {}, 'config is empty')
+
+  prepCase(`gpaBuilder.addFilter('n', 2)`)
+  gpaBuilder.addFilter('n', 2)
+  spok(t, withDecodedBytes(gpaBuilder.config), {
+    filters: [{ memcmp: { offset: 0, bytes: Buffer.from([2]) } }],
+  })
+
+  prepCase(`gpaBuilder.addFilter('nn', 4)`)
+  gpaBuilder.addFilter('nn', 4)
+  spok(t, withDecodedBytes(gpaBuilder.config), {
+    filters: [{ memcmp: { offset: 1, bytes: Buffer.from([4]) } }],
+  })
+
+  prepCase(`add both of the above`)
+  gpaBuilder.addFilter('n', 2).addFilter('nn', 4)
+  spok(t, withDecodedBytes(gpaBuilder.config), {
+    filters: [
+      {
+        memcmp: { offset: 0, bytes: Buffer.from([2]) },
+      },
+      { memcmp: { offset: 1, bytes: Buffer.from([4]) } },
+    ],
+  })
+
+  prepCase(`gpaBuilder.dataSize()`)
+  gpaBuilder.dataSize()
+  spok(t, withDecodedBytes(gpaBuilder.config), {
+    filters: [{ dataSize: 2 }],
+  })
+
+  prepCase(`gpaBuilder.dataSize().addFilter('nn', 4)`)
+  gpaBuilder.dataSize().addFilter('nn', 4)
+  spok(t, withDecodedBytes(gpaBuilder.config), {
+    filters: [
+      { dataSize: 2 },
+      { memcmp: { offset: 1, bytes: Buffer.from([4]) } },
+    ],
+  })
+
+  t.end()
+})

--- a/beet-solana/test/gpa.ts
+++ b/beet-solana/test/gpa.ts
@@ -1,6 +1,12 @@
 import test from 'tape'
 import spok from 'spok'
-import { BeetStruct } from '@metaplex-foundation/beet'
+import {
+  BeetStruct,
+  fixedSizeUtf8String,
+  i16,
+  i32,
+  u16,
+} from '@metaplex-foundation/beet'
 import { u8 } from '@metaplex-foundation/beet'
 import {
   GetProgramAccountsConfig,
@@ -10,15 +16,9 @@ import {
 } from '@solana/web3.js'
 import { GpaBuilder } from '../src/gpa'
 import base58 from 'bs58'
-
-import * as util from 'util'
+import { dbg } from './utils'
 
 const PROGRAM_ID = new PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ')
-
-// @ts-ignore
-function inspect(obj: any, colors = true) {
-  console.log(util.inspect(obj, { colors, depth: 5 }))
-}
 
 function isMemcmpFilter(x: GetProgramAccountsFilter): x is MemcmpFilter {
   return (x as MemcmpFilter).memcmp != null
@@ -123,6 +123,156 @@ test('gpa: fixed struct with two u8s', (t) => {
       { dataSize: 2 },
       { memcmp: { offset: 1, bytes: Buffer.from([4]) } },
     ],
+  })
+
+  t.end()
+})
+
+type ResultsArgs = Pick<Results, 'win' | 'totalWin' | 'losses'>
+class Results {
+  constructor(
+    readonly win: number,
+    readonly totalWin: number,
+    readonly losses: number
+  ) {}
+
+  static readonly struct = new BeetStruct<Results, ResultsArgs>(
+    [
+      ['win', u8],
+      ['totalWin', u16],
+      ['losses', i32],
+    ],
+    (args) => new Results(args.win!, args.totalWin!, args.losses!),
+    'Results'
+  )
+}
+
+type TraderArgs = Pick<Trader, 'name' | 'results' | 'age'>
+class Trader {
+  constructor(
+    readonly name: string,
+    readonly results: Results,
+    readonly age: number
+  ) {}
+
+  static readonly struct = new BeetStruct<Trader, TraderArgs>(
+    [
+      ['name', fixedSizeUtf8String(4)], // offset: 0 (size: 2 * 4)
+      ['results', Results.struct], // offset: 8 (size: 7)
+      ['age', u8], // offset: 8 + 7 = 15
+    ],
+    (args) => new Trader(args.name!, args.results!, args.age!),
+    'Trader'
+  )
+}
+
+test('gpa: fixed struct with three ints', (t) => {
+  let gpaBuilder: GpaBuilder<Results> = GpaBuilder.fromStruct<Results>(
+    PROGRAM_ID,
+    Results.struct
+  )
+  function prepCase(comment: string) {
+    t.comment(comment)
+    gpaBuilder = GpaBuilder.fromStruct<Results>(PROGRAM_ID, Results.struct)
+  }
+
+  prepCase(`gpaBuilder.addFilter('win', 2)`)
+  gpaBuilder.addFilter('win', 2)
+  spok(t, withDecodedBytes(gpaBuilder.config), {
+    filters: [{ memcmp: { offset: 0, bytes: Buffer.from([2]) } }],
+  })
+
+  prepCase(`gpaBuilder.addFilter('totalWin', 8)`)
+  gpaBuilder.addFilter('totalWin', 8)
+  spok(t, withDecodedBytes(gpaBuilder.config), {
+    filters: [{ memcmp: { offset: 1, bytes: Buffer.from([8]) } }],
+  })
+
+  prepCase(`gpaBuilder.addFilter('losses', -7)`)
+  gpaBuilder.addFilter('losses', -7)
+  spok(t, withDecodedBytes(gpaBuilder.config), {
+    filters: [{ memcmp: { offset: 3, bytes: Buffer.from([-7]) } }],
+  })
+
+  prepCase(`gpaBuilder.addFilter('totalWin', 8).addFilter('losses', -7)`)
+  gpaBuilder.addFilter('totalWin', 8).addFilter('losses', -7)
+  spok(t, withDecodedBytes(gpaBuilder.config), {
+    filters: [
+      { memcmp: { offset: 1, bytes: Buffer.from([8]) } },
+      { memcmp: { offset: 3, bytes: Buffer.from([-7]) } },
+    ],
+  })
+
+  t.end()
+})
+
+test.only('gpa: fixed struct nested inside fixed struct', (t) => {
+  // Expected Filters
+  const nameFilter = (name: string) => ({
+    memcmp: {
+      offset: 0,
+      bytes: Buffer.concat([
+        Buffer.from([4, 0, 0, 0]), // length
+        Buffer.from(name),
+      ]),
+    },
+  })
+  const ageFilter = (age: number) => ({
+    memcmp: { offset: 15, bytes: Buffer.from([age]) },
+  })
+
+  const resultsFilter = (results: Results) => {
+    const bytes = Results.struct.serialize(results)[0]
+    return {
+      memcmp: {
+        offset: 8,
+        bytes,
+      },
+    }
+  }
+
+  // Prep
+  let gpaBuilder: GpaBuilder<Trader> = GpaBuilder.fromStruct<Trader>(
+    PROGRAM_ID,
+    Trader.struct
+  )
+  function prepCase(comment: string) {
+    t.comment(comment)
+    gpaBuilder = GpaBuilder.fromStruct<Trader>(PROGRAM_ID, Trader.struct)
+  }
+
+  // Tests
+  prepCase(
+    `name whic is before results struct - gpaBuilder.addFilter('name', 'trad')`
+  )
+  gpaBuilder.addFilter('name', 'trad')
+  spok(t, withDecodedBytes(gpaBuilder.config), {
+    filters: [nameFilter('trad')],
+  })
+
+  prepCase(
+    `age which is after results struct - gpaBuilder.addFilter('age', 99)`
+  )
+  gpaBuilder.addFilter('age', 99)
+  spok(t, withDecodedBytes(gpaBuilder.config), {
+    filters: [ageFilter(99)],
+  })
+
+  prepCase(`gpaBuilder.addFilter('name', 'trad').addFilter('age', 99)`)
+  gpaBuilder.addFilter('name', 'trad').addFilter('age', 99)
+  spok(t, withDecodedBytes(gpaBuilder.config), {
+    filters: [nameFilter('trad'), ageFilter(99)],
+  })
+
+  prepCase(`gpaBuilder.addFilter('results', { win, totalWin, losses })`)
+  const results = {
+    win: 3,
+    totalWin: 4,
+    losses: -100,
+  }
+  gpaBuilder.addFilter('results', results)
+  spok(t, withDecodedBytes(gpaBuilder.config), {
+    filters: [resultsFilter(results)],
   })
 
   t.end()

--- a/beet-solana/test/gpa.ts
+++ b/beet-solana/test/gpa.ts
@@ -3,7 +3,7 @@ import spok from 'spok'
 import { BeetStruct } from '@metaplex-foundation/beet'
 import { u8 } from '@metaplex-foundation/beet'
 import { PROGRAM_ID, Results, withDecodedBytes } from './utils'
-import { GpaBuilder } from 'src/beet-solana'
+import { GpaBuilder } from '../src/beet-solana'
 
 test('gpa: fixed struct with one u8', (t) => {
   type Args = {

--- a/beet-solana/test/gpa.ts
+++ b/beet-solana/test/gpa.ts
@@ -1,47 +1,9 @@
 import test from 'tape'
 import spok from 'spok'
-import {
-  BeetStruct,
-  fixedSizeUtf8String,
-  i16,
-  i32,
-  u16,
-} from '@metaplex-foundation/beet'
+import { BeetStruct } from '@metaplex-foundation/beet'
 import { u8 } from '@metaplex-foundation/beet'
-import {
-  GetProgramAccountsConfig,
-  GetProgramAccountsFilter,
-  MemcmpFilter,
-  PublicKey,
-} from '@solana/web3.js'
-import { GpaBuilder } from '../src/gpa'
-import base58 from 'bs58'
-import { dbg } from './utils'
-
-const PROGRAM_ID = new PublicKey('cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ')
-
-function isMemcmpFilter(x: GetProgramAccountsFilter): x is MemcmpFilter {
-  return (x as MemcmpFilter).memcmp != null
-}
-
-function withDecodedBytes(config: GetProgramAccountsConfig) {
-  const filters = []
-  if (config.filters != null) {
-    for (const x of config.filters) {
-      if (isMemcmpFilter(x)) {
-        filters.push({
-          memcmp: {
-            offset: x.memcmp.offset,
-            bytes: base58.decode(x.memcmp.bytes),
-          },
-        })
-      } else {
-        filters.push({ dataSize: x.dataSize })
-      }
-    }
-  }
-  return { ...config, filters }
-}
+import { PROGRAM_ID, Results, withDecodedBytes } from './utils'
+import { GpaBuilder } from 'src/beet-solana'
 
 test('gpa: fixed struct with one u8', (t) => {
   type Args = {
@@ -128,44 +90,6 @@ test('gpa: fixed struct with two u8s', (t) => {
   t.end()
 })
 
-type ResultsArgs = Pick<Results, 'win' | 'totalWin' | 'losses'>
-class Results {
-  constructor(
-    readonly win: number,
-    readonly totalWin: number,
-    readonly losses: number
-  ) {}
-
-  static readonly struct = new BeetStruct<Results, ResultsArgs>(
-    [
-      ['win', u8],
-      ['totalWin', u16],
-      ['losses', i32],
-    ],
-    (args) => new Results(args.win!, args.totalWin!, args.losses!),
-    'Results'
-  )
-}
-
-type TraderArgs = Pick<Trader, 'name' | 'results' | 'age'>
-class Trader {
-  constructor(
-    readonly name: string,
-    readonly results: Results,
-    readonly age: number
-  ) {}
-
-  static readonly struct = new BeetStruct<Trader, TraderArgs>(
-    [
-      ['name', fixedSizeUtf8String(4)], // offset: 0 (size: 2 * 4)
-      ['results', Results.struct], // offset: 8 (size: 7)
-      ['age', u8], // offset: 8 + 7 = 15
-    ],
-    (args) => new Trader(args.name!, args.results!, args.age!),
-    'Trader'
-  )
-}
-
 test('gpa: fixed struct with three ints', (t) => {
   let gpaBuilder: GpaBuilder<Results> = GpaBuilder.fromStruct<Results>(
     PROGRAM_ID,
@@ -201,78 +125,6 @@ test('gpa: fixed struct with three ints', (t) => {
       { memcmp: { offset: 1, bytes: Buffer.from([8]) } },
       { memcmp: { offset: 3, bytes: Buffer.from([-7]) } },
     ],
-  })
-
-  t.end()
-})
-
-test.only('gpa: fixed struct nested inside fixed struct', (t) => {
-  // Expected Filters
-  const nameFilter = (name: string) => ({
-    memcmp: {
-      offset: 0,
-      bytes: Buffer.concat([
-        Buffer.from([4, 0, 0, 0]), // length
-        Buffer.from(name),
-      ]),
-    },
-  })
-  const ageFilter = (age: number) => ({
-    memcmp: { offset: 15, bytes: Buffer.from([age]) },
-  })
-
-  const resultsFilter = (results: Results) => {
-    const bytes = Results.struct.serialize(results)[0]
-    return {
-      memcmp: {
-        offset: 8,
-        bytes,
-      },
-    }
-  }
-
-  // Prep
-  let gpaBuilder: GpaBuilder<Trader> = GpaBuilder.fromStruct<Trader>(
-    PROGRAM_ID,
-    Trader.struct
-  )
-  function prepCase(comment: string) {
-    t.comment(comment)
-    gpaBuilder = GpaBuilder.fromStruct<Trader>(PROGRAM_ID, Trader.struct)
-  }
-
-  // Tests
-  prepCase(
-    `name whic is before results struct - gpaBuilder.addFilter('name', 'trad')`
-  )
-  gpaBuilder.addFilter('name', 'trad')
-  spok(t, withDecodedBytes(gpaBuilder.config), {
-    filters: [nameFilter('trad')],
-  })
-
-  prepCase(
-    `age which is after results struct - gpaBuilder.addFilter('age', 99)`
-  )
-  gpaBuilder.addFilter('age', 99)
-  spok(t, withDecodedBytes(gpaBuilder.config), {
-    filters: [ageFilter(99)],
-  })
-
-  prepCase(`gpaBuilder.addFilter('name', 'trad').addFilter('age', 99)`)
-  gpaBuilder.addFilter('name', 'trad').addFilter('age', 99)
-  spok(t, withDecodedBytes(gpaBuilder.config), {
-    filters: [nameFilter('trad'), ageFilter(99)],
-  })
-
-  prepCase(`gpaBuilder.addFilter('results', { win, totalWin, losses })`)
-  const results = {
-    win: 3,
-    totalWin: 4,
-    losses: -100,
-  }
-  gpaBuilder.addFilter('results', results)
-  spok(t, withDecodedBytes(gpaBuilder.config), {
-    filters: [resultsFilter(results)],
   })
 
   t.end()

--- a/beet-solana/test/utils/index.ts
+++ b/beet-solana/test/utils/index.ts
@@ -1,4 +1,22 @@
+import {
+  BeetStruct,
+  fixedSizeUtf8String,
+  i32,
+  u16,
+  u8,
+} from '@metaplex-foundation/beet'
+import {
+  GetProgramAccountsConfig,
+  GetProgramAccountsFilter,
+  MemcmpFilter,
+  PublicKey,
+} from '@solana/web3.js'
+import base58 from 'bs58'
 import * as util from 'util'
+
+export const PROGRAM_ID = new PublicKey(
+  'cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ'
+)
 
 export function inspect(obj: any, colors = true) {
   console.log(util.inspect(obj, { colors, depth: 5 }))
@@ -7,4 +25,68 @@ export function inspect(obj: any, colors = true) {
 export function dbg(obj: any) {
   inspect(obj)
   return obj
+}
+
+export function isMemcmpFilter(x: GetProgramAccountsFilter): x is MemcmpFilter {
+  return (x as MemcmpFilter).memcmp != null
+}
+
+export function withDecodedBytes(config: GetProgramAccountsConfig) {
+  const filters = []
+  if (config.filters != null) {
+    for (const x of config.filters) {
+      if (isMemcmpFilter(x)) {
+        filters.push({
+          memcmp: {
+            offset: x.memcmp.offset,
+            bytes: base58.decode(x.memcmp.bytes),
+          },
+        })
+      } else {
+        filters.push({ dataSize: x.dataSize })
+      }
+    }
+  }
+  return { ...config, filters }
+}
+
+// -----------------
+// Sample Structs
+// -----------------
+export type ResultsArgs = Pick<Results, 'win' | 'totalWin' | 'losses'>
+export class Results {
+  constructor(
+    readonly win: number,
+    readonly totalWin: number,
+    readonly losses: number
+  ) {}
+
+  static readonly struct = new BeetStruct<Results, ResultsArgs>(
+    [
+      ['win', u8],
+      ['totalWin', u16],
+      ['losses', i32],
+    ],
+    (args: ResultsArgs) => new Results(args.win!, args.totalWin!, args.losses!),
+    'Results'
+  )
+}
+
+export type TraderArgs = Pick<Trader, 'name' | 'results' | 'age'>
+export class Trader {
+  constructor(
+    readonly name: string,
+    readonly results: Results,
+    readonly age: number
+  ) {}
+
+  static readonly struct = new BeetStruct<Trader, TraderArgs>(
+    [
+      ['name', fixedSizeUtf8String(4)], // offset: 0 (size: 2 * 4)
+      ['results', Results.struct], // offset: 8 (size: 7)
+      ['age', u8], // offset: 8 + 7 = 15
+    ],
+    (args) => new Trader(args.name!, args.results!, args.age!),
+    'Trader'
+  )
 }

--- a/beet-solana/test/utils/index.ts
+++ b/beet-solana/test/utils/index.ts
@@ -1,0 +1,10 @@
+import * as util from 'util'
+
+export function inspect(obj: any, colors = true) {
+  console.log(util.inspect(obj, { colors, depth: 5 }))
+}
+
+export function dbg(obj: any) {
+  inspect(obj)
+  return obj
+}

--- a/beet-solana/test/utils/index.ts
+++ b/beet-solana/test/utils/index.ts
@@ -90,3 +90,27 @@ export class Trader {
     'Trader'
   )
 }
+
+// Expected Filters
+export const nameFilter = (name: string) => ({
+  memcmp: {
+    offset: 0,
+    bytes: Buffer.concat([
+      Buffer.from([4, 0, 0, 0]), // length
+      Buffer.from(name),
+    ]),
+  },
+})
+export const ageFilter = (age: number) => ({
+  memcmp: { offset: 15, bytes: Buffer.from([age]) },
+})
+
+export const resultsFilter = (results: Results) => {
+  const bytes = Results.struct.serialize(results)[0]
+  return {
+    memcmp: {
+      offset: 8,
+      bytes,
+    },
+  }
+}

--- a/beet/src/struct.fixable.ts
+++ b/beet/src/struct.fixable.ts
@@ -30,14 +30,14 @@ export class FixableBeetStruct<Class, Args = Partial<Class>>
    * purposes
    */
   constructor(
-    private readonly fields: BeetField<Args, any>[],
+    readonly fields: BeetField<Args, any>[],
     private readonly construct: (args: Args) => Class,
     readonly description = FixableBeetStruct.description
   ) {
     let minByteSize = 0
     if (logDebug.enabled) {
       const flds = fields
-        .map(([key, val]: BeetField<Args>) => {
+        .map(([key, val]: BeetField<Args, any>) => {
           if (isFixedSizeBeet(val)) {
             minByteSize += val.byteSize
           }

--- a/beet/src/struct.ts
+++ b/beet/src/struct.ts
@@ -28,7 +28,7 @@ export class BeetStruct<Class, Args = Partial<Class>>
    * purposes
    */
   constructor(
-    private readonly fields: FixedBeetField<Args>[],
+    readonly fields: FixedBeetField<Args>[],
     private readonly construct: (args: Args) => Class,
     readonly description = BeetStruct.description
   ) {


### PR DESCRIPTION
# Summary

Adding GPA Builders relying on beet to provide an interface to configure filters for
`getProgramAccount`s

At this point one level of nesting is supported (i.e. a struct field containing another
struct).

A filter matching that entire nested struct or matching a field of that nested struct can be
built via `addInnerFilter`.

## Remaining Work

If deeper levels of nesting are required those can be added.

More detailed debugging around GPA builder functionality could be added if needed

* * *

Quoting from the [Readme GPA
Section](https://github.com/metaplex-foundation/beet/blob/thlorenz/feat/gpa-builder/beet-solana/README.md#gpa-builders)

## GPA Builders

solana-beet uses `beet`s knowledge about account layouts to provide `GpaBuilder`s for
them which allow to filter by account data size and content.

1. Create a GPA Builder via `const gpaBuilder = GpaBuilder.fromStruct(programId, accountStruct)`
2. add filters via `gpaBuilder.dataSize`, `gpaBuilder.addFilter` or `gpaBuilder.addInnerFilter`
3. execute `gpaBuilder.run(connection)` which will return all accounts matching the specified
filters

### Examples

#### Simple struct with primitives

```ts
export type ResultsArgs = Pick<Results, 'win' | 'totalWin' | 'losses'>
export class Results {
  constructor(
    readonly win: number,
    readonly totalWin: number,
    readonly losses: number
  ) {}

  static readonly struct = new BeetStruct<Results, ResultsArgs>(
    [
      ['win', u8],
      ['totalWin', u16],
      ['losses', i32],
    ],
    (args: ResultsArgs) => new Results(args.win!, args.totalWin!, args.losses!),
    'Results'
  )
}

const gpaBuilder = GpaBuilder.fromStruct(PROGRAM_ID, Results.struct)
const accounts = await gpaBuilder
  .addFilter('totalWin', 8)
  .addFilter('losses', -7)
  .run()
```

#### Matching on Complete Nested Struct

_Using `Results` struct from above_

```ts
export type TraderArgs = Pick<Trader, 'name' | 'results' | 'age'>
export class Trader {
  constructor(
    readonly name: string,
    readonly results: Results,
    readonly age: number
  ) {}

  static readonly struct = new BeetStruct<Trader, TraderArgs>(
    [
      ['name', fixedSizeUtf8String(4)],
      ['results', Results.struct],
      ['age', u8],
    ],
    (args) => new Trader(args.name!, args.results!, args.age!),
    'Trader'
  )
}

const gpaBuilder = GpaBuilder.fromStruct<Trader>(
  PROGRAM_ID,
  Trader.struct
)

const results = {
  win: 3,
  totalWin: 4,
  losses: -100,
}

const accounts = await gpaBuilder.addFilter('results', results).run()
```

#### Matching on Part of Nested Struct

_Using `Trader` struct from above_

```ts
const gpaBuilder = GpaBuilder.fromStruct<Trader>(
  PROGRAM_ID,
  Trader.struct
)

const account = await gpaBuilder
  .addInnerFilter('results.totalWin', 8)
  .addInnerFilter('results.win', 2)
  .run()
```

- beet: exposing struct fields
- gpa: initial gpa implementation added to beet-solana
- test: struct with primitives only
- types: correctly typed BeetField in `fromStruct`
- tests: around nested structs
- test: separate out nested struct tests
- nested: supporting nested structs
- test: simplifying some types in setups
- docs: adding doc comments
- docs: documenting GPA builders in readme
