### PR TITLE
feat: support data enums with scalar variants

### DIFF
--- a/beet/src/beets/enums.ts
+++ b/beet/src/beets/enums.ts
@@ -11,6 +11,7 @@ import { u8 } from './numbers'
 import { strict as assert } from 'assert'
 import { isBeetStruct } from '../struct'
 import { isFixableBeetStruct } from '../struct.fixable'
+import { unit } from './unit'
 
 // -----------------
 // Fixed Scalar Enum
@@ -176,10 +177,12 @@ export function dataEnum<T, Key extends keyof T = keyof T>(
   variants: DataEnumBeet<T, Key>[]
 ) {
   for (const [_, beet] of variants) {
-    // NOTE: tried to enforce this with types but failed to do so for now
     assert(
-      isBeetStruct(beet) || isFixableBeetStruct(beet),
-      'dataEnum: data beet must be a struct'
+      isBeetStruct(beet) ||
+        isFixableBeetStruct(beet) ||
+        // scalar variant
+        beet === unit,
+      'dataEnum: variants must be a data beet struct or a scalar unit'
     )
   }
 

--- a/beet/test/compat/fixtures/data_enums.json
+++ b/beet/test/compat/fixtures/data_enums.json
@@ -137,5 +137,33 @@
         0
       ]
     }
+  ],
+  "data_scalar_mix": [
+    {
+      "value": {
+        "Data": {
+          "data_field": 333
+        }
+      },
+      "data": [
+        0,
+        77,
+        1,
+        0,
+        0
+      ]
+    },
+    {
+      "value": "Up",
+      "data": [
+        1
+      ]
+    },
+    {
+      "value": "Down",
+      "data": [
+        2
+      ]
+    }
   ]
 }

--- a/beet/test/unit/data-enums.ts
+++ b/beet/test/unit/data-enums.ts
@@ -9,6 +9,7 @@ import {
   isFixableBeet,
   u8,
   uniformFixedSizeArray,
+  unit,
   utf8String,
 } from '../../src/beet'
 
@@ -120,7 +121,10 @@ test('data-enums: direct fixed data', (t) => {
     dataEnum<Ty>([['Data', u8]])
     t.fail('should throw')
   } catch (err: any) {
-    t.match(err.toString(), /beet must be a struct/)
+    t.match(
+      err.toString(),
+      /variants must be a data beet struct or a scalar unit/
+    )
   }
   t.end()
 })
@@ -133,7 +137,25 @@ test('data-enums: direct fixable data', (t) => {
     dataEnum<Ty>([['Data', utf8String]])
     t.fail('should throw')
   } catch (err: any) {
-    t.match(err.toString(), /beet must be a struct/)
+    t.match(
+      err.toString(),
+      /variants must be a data beet struct or a scalar unit/
+    )
   }
+  t.end()
+})
+
+test('data-enums: mixed variants', (t) => {
+  type Ty = {
+    Data: { s: string }
+    Scalar: void
+  }
+  const beet = dataEnum<Ty>([
+    ['Data', new FixableBeetArgsStruct([['s', utf8String]])],
+    ['Scalar', unit],
+  ])
+  checkCase(t, beet, { Data: { s: 'hello' } })
+  checkCase(t, beet, { Scalar: void 0 })
+  checkCase(t, beet, { Scalar: undefined })
   t.end()
 })

--- a/tools/bsamples/src/data_enums.rs
+++ b/tools/bsamples/src/data_enums.rs
@@ -22,10 +22,18 @@ pub enum CollectionInfo {
     },
 }
 
+#[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+pub enum DataScalarMix {
+    Data { data_field: u32 },
+    Up,
+    Down,
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct DataEnums {
     collections: Vec<Sample<CollectionInfo>>,
     simples: Vec<Sample<Simple>>,
+    data_scalar_mix: Vec<Sample<DataScalarMix>>,
 }
 
 pub fn produce_data_enums() -> Result<DataEnums> {
@@ -42,8 +50,15 @@ pub fn produce_data_enums() -> Result<DataEnums> {
         Simple::Second { second_field: 22 },
     ])?;
 
+    let data_scalar_mix = produce_samples(vec![
+        DataScalarMix::Data { data_field: 333 },
+        DataScalarMix::Up,
+        DataScalarMix::Down,
+    ])?;
+
     Ok(DataEnums {
         simples,
         collections,
+        data_scalar_mix,
     })
 }


### PR DESCRIPTION
## Example

```ts
type DataScalarMix = {
  Data: { data_field: number }
  Up: void
  Down: void
}

const beet = dataEnum<DataScalarMix>([
  ['Data', new BeetArgsStruct([['data_field', u32]])],
  ['Up', unit],
  ['Down', unit],
])
```

Via the `unit` beet type we can now represent non-data variants as part of data enums.

A data enum is used as soon as _any_ variant is non-scalar.
