### PR TITLE
Upgrade solana/web3.js

### DIFF
--- a/beet-solana/package.json
+++ b/beet-solana/package.json
@@ -30,7 +30,7 @@
   ],
   "dependencies": {
     "@metaplex-foundation/beet": ">=0.1.0",
-    "@solana/web3.js": "^1.56.2",
+    "@solana/web3.js": "^1.95.4",
     "bs58": "^5.0.0",
     "debug": "^4.3.4"
   },


### PR DESCRIPTION
gm guys, 

this PR is just to upgrade solana/web3.js to the latest.

I have failed to build and test this. but from reading the code, it should work. the only major change that I see that would have failed is the memcmp in the gpa calls, basically it has to be base58 encoded in >v1.95, which you already did in the tests.

regards,
miester.